### PR TITLE
Implement inbound trunk handling with dialplan

### DIFF
--- a/imageroot/actions/add-route/20writeroute
+++ b/imageroot/actions/add-route/20writeroute
@@ -18,14 +18,14 @@ query = ""
 
 # Chek if a domain is registred
 with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE domain=\'{data["domain"]}\';\n', file=psql.stdin)
+        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND route_type=\'domain\';\n', file=psql.stdin)
         proxy_route , _ = psql.communicate()
         proxy_route = json.loads(proxy_route)
 
 if not proxy_route:
     # Add domain into nethvoice_proxy_routes table if not already exists
     with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'WITH proxy_route AS (INSERT INTO nethvoice_proxy_routes (domain) VALUES (\'{data["domain"]}\') RETURNING *) SELECT JSON_AGG(proxy_route.*) from proxy_route;\n', file=psql.stdin)
+        print(f'WITH proxy_route AS (INSERT INTO nethvoice_proxy_routes (target, route_type) VALUES (\'{data["domain"]}\', \'domain\') RETURNING *) SELECT JSON_AGG(proxy_route.*) from proxy_route;\n', file=psql.stdin)
         proxy_route, _ = psql.communicate()
         proxy_route = json.loads(proxy_route)
 

--- a/imageroot/actions/add-trunk/20writetrunk
+++ b/imageroot/actions/add-trunk/20writetrunk
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import subprocess
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+# Prepare the query with the new route configuration
+query = ""
+
+# Chek if a trunk is registred
+with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["rule"]}\' AND route_type=\'trunk\';\n', file=psql.stdin)
+        proxy_route , _ = psql.communicate()
+        proxy_route = json.loads(proxy_route)
+
+if not proxy_route:
+    # Add trunk route into nethvoice_proxy_routes table if not already exists
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print(f'WITH proxy_route AS (INSERT INTO nethvoice_proxy_routes (target, route_type) VALUES (\'{data["rule"]}\', \'trunk\') RETURNING *) SELECT JSON_AGG(proxy_route.*) from proxy_route;\n', file=psql.stdin)
+        proxy_route, _ = psql.communicate()
+        proxy_route = json.loads(proxy_route)
+
+        # Create dialplan for the rule
+        query += (
+                f'INSERT INTO dialplan (dpid, pr, match_op, match_exp, match_len, subst_exp, repl_exp, attrs) VALUES (2,1,1,\'sip:{data["rule"]}.*@.*\',0,\'(.*)\',{proxy_route[0]["setid"]},{proxy_route[0]["setid"]});\n'
+                  )
+
+# Add trunk route into dispatcher table
+query += (
+        f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
+        f'INSERT INTO dispatcher (setid,  destination, description) VALUES ({proxy_route[0]["setid"]},\'{data["destination"]["uri"]}\',\'{data["destination"]["description"]}\');\n'
+        )
+
+# Write the route
+with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:
+        print(query,file=psql.stdin)

--- a/imageroot/actions/add-trunk/30reload_modules
+++ b/imageroot/actions/add-trunk/30reload_modules
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# If the control reaches this step, reload kamailio modules.
+
+cat << EOF | podman exec -i kamailio kamcmd > /dev/null
+dialplan.reload
+dispatcher.reload
+EOF

--- a/imageroot/actions/add-trunk/validate-input.json
+++ b/imageroot/actions/add-trunk/validate-input.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "add-trunk input",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/add-trunk.json",
+  "description": "Reserve a trunk for a NethVoice module",
+  "examples": [
+    {
+      "rule": "05551594XX",
+      "destination": {
+        "uri": "sip:127.0.0.1:5080",
+        "description": " module1"
+      }
+    }
+  ],
+  "type": "object",
+  "required": ["rule", "destination"],
+  "properties": {
+    "rule": {
+      "type": "string",
+      "title": "pattern matching rule",
+      "minLength": 1,
+      "examples": ["05551594XX"]
+    },
+    "destination": {
+      "type": "object",
+      "title": "Backend Asterisk",
+      "required": ["uri", "description"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Description of the destination, can be used for store the NethVoice module ID/UUID"
+        }
+      }
+    }
+  }
+}

--- a/imageroot/actions/get-route/20readroute
+++ b/imageroot/actions/get-route/20readroute
@@ -17,7 +17,7 @@ route = {}
 
 # Chek if a domain is registred
 with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE domain=\'{data["domain"]}\';\n', file=psql.stdin)
+        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND route_type=\'domain\';\n', file=psql.stdin)
         proxy_route , _ = psql.communicate()
         proxy_route = json.loads(proxy_route)
 

--- a/imageroot/actions/get-trunk/20readtrunk
+++ b/imageroot/actions/get-trunk/20readtrunk
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import subprocess
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+route = {}
+
+# Chek if a trunk is registred
+with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["rule"]}\' AND route_type=\'trunk\';\n', file=psql.stdin)
+        proxy_route , _ = psql.communicate()
+        proxy_route = json.loads(proxy_route)
+
+if proxy_route:
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print(f'SELECT json_agg(dispatcher.*) FROM dispatcher WHERE setid=\'{proxy_route[0]["setid"]}\';\n', file=psql.stdin)
+        destination, _ = psql.communicate()
+        destination = json.loads(destination)
+
+    route["destination"] = { "uri": destination[0]["destination"], "description": destination[0]["description"] }
+
+json.dump(route, fp=sys.stdout)

--- a/imageroot/actions/get-trunk/validate-input.json
+++ b/imageroot/actions/get-trunk/validate-input.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "get-trunk input",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/get-trunk-input.json",
+  "description": "Retrieve a trunk",
+  "examples": [
+    {
+      "rule": "05551594XX"
+    }
+  ],
+  "type": "object",
+  "required": ["rule"],
+  "properties": {
+    "rule": {
+      "type": "string",
+      "title": "pattern matching rule",
+      "minLength": 1,
+      "examples": ["05551594XX"]
+    }
+  }
+}

--- a/imageroot/actions/get-trunk/validate-output.json
+++ b/imageroot/actions/get-trunk/validate-output.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "get-route output",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/add-route-output.json",
+  "description": "Retrieve a Voip route",
+  "examples": [
+    {
+      "destination": {
+        "uri": "sip:127.0.0.1:5080",
+        "description": " module1"
+      }
+    }
+  ],
+  "type": "object",
+  "oneOf": [
+    {
+      "required": ["destination"],
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "type": "object",
+          "required": ["uri", "description"],
+          "properties": {
+            "uri": {
+              "type": "string",
+              "title": "Backend Asterisk",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string",
+              "title": "Description of the destination, can be used for store the NethVoice module ID/UUID",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "additionalProperties": false,
+      "properties": {}
+    }
+  ]
+}

--- a/imageroot/actions/list-routes/20readroutes
+++ b/imageroot/actions/list-routes/20readroutes
@@ -15,7 +15,7 @@ data = json.load(sys.stdin)
 
 # Chek if a domain is registred
 with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print('SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes;\n', file=psql.stdin)
+        print('SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE route_type=\'domain\';\n', file=psql.stdin)
         proxy_routes , _ = psql.communicate()
         proxy_routes = json.loads(proxy_routes)
 
@@ -23,7 +23,7 @@ routes = []
 
 for proxy_route in proxy_routes:
     route = {}
-    route["domain"] = proxy_route["domain"]
+    route["domain"] = proxy_route["target"]
 
     with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
         print(f'SELECT json_agg(dispatcher.*) FROM dispatcher WHERE setid=\'{proxy_route["setid"]}\';\n', file=psql.stdin)

--- a/imageroot/actions/list-trunks/20readtrunks
+++ b/imageroot/actions/list-trunks/20readtrunks
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import subprocess
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+# Chek if a trunk is registred
+with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print('SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE route_type=\'trunk\';\n', file=psql.stdin)
+        proxy_routes , _ = psql.communicate()
+        proxy_routes = json.loads(proxy_routes)
+
+routes = []
+
+for proxy_route in proxy_routes:
+    route = {}
+    route["rule"] = proxy_route["target"]
+
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+        print(f'SELECT json_agg(dispatcher.*) FROM dispatcher WHERE setid=\'{proxy_route["setid"]}\';\n', file=psql.stdin)
+        destination, _ = psql.communicate()
+        destination = json.loads(destination)
+
+    route["destination"] = { "uri": destination[0]["destination"], "description": destination[0]["description"] }
+    routes.append(route)
+json.dump(routes, fp=sys.stdout)
+

--- a/imageroot/actions/list-trunks/validate-output.json
+++ b/imageroot/actions/list-trunks/validate-output.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "list-trunks output",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/list-trunks-output.json",
+  "description": "Retrieve a list of trunk",
+  "examples": [
+    [
+      {
+        "rule": "05551594XX",
+        "destination": {
+          "uri": "sip:127.0.0.1:5080",
+          "description": " module1"
+        }
+      },
+      {
+        "rule": "05551595XX",
+        "destination": {
+          "uri": "sip:127.0.0.1:5081",
+          "description": " module2"
+        }
+      }
+    ],
+    []
+  ],
+  "type": "array",
+  "anyOf": [
+    {
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "required": ["rule", "destination"],
+        "additionalProperties": false,
+        "properties": {
+          "rule": {
+            "type": "string",
+            "minLength": 1
+          },
+          "destination": {
+            "type": "object",
+            "required": ["uri", "description"],
+            "title": "Backend Asterisk",
+            "additionalProperties": false,
+            "properties": {
+              "uri": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string",
+                "title": "Description of the destination, can be used for store the NethVoice module ID/UUID",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "maxItems": 0
+    }
+  ]
+}

--- a/imageroot/actions/remove-route/20removeroute
+++ b/imageroot/actions/remove-route/20removeroute
@@ -15,7 +15,7 @@ data = json.load(sys.stdin)
 
 # Chek if a domain is registred
 with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE domain=\'{data["domain"]}\';\n', file=psql.stdin)
+        print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND route_type=\'domain\';\n', file=psql.stdin)
         proxy_route , _ = psql.communicate()
         proxy_route = json.loads(proxy_route)
 
@@ -35,7 +35,7 @@ if proxy_route:
     # If the list is empty or the address list is not given, delete the route
     if address[0]["count"] == 0 or "address" not in data:
         query = (
-                f'DELETE FROM nethvoice_proxy_routes WHERE domain=\'{data["domain"]}\' AND setid={proxy_route[0]["setid"]};\n'
+                f'DELETE FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND setid={proxy_route[0]["setid"]} AND route_type=\'domain\';\n'
                 f'DELETE FROM domain WHERE domain=\'{data["domain"]}\' AND did=\'{data["domain"]}\';\n'
                 f'DELETE FROM dialplan WHERE match_exp=\'{data["domain"]}\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
                 f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'

--- a/imageroot/actions/remove-trunk/20removetrunk
+++ b/imageroot/actions/remove-trunk/20removetrunk
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import subprocess
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+# Chek if a trunk is registred
+with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
+    print(f'SELECT COALESCE(json_agg(nethvoice_proxy_routes.*), \'[]\'::json) FROM nethvoice_proxy_routes WHERE target=\'{data["rule"]}\' AND route_type=\'trunk\';\n', file=psql.stdin)
+    proxy_route , _ = psql.communicate()
+    proxy_route = json.loads(proxy_route)
+
+if proxy_route:
+    query = (
+            f'DELETE FROM nethvoice_proxy_routes WHERE target=\'{data["rule"]}\' AND setid={proxy_route[0]["setid"]} AND route_type=\'trunk\';\n'
+            f'DELETE FROM dialplan WHERE match_exp=\'{data["rule"]}\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
+            f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
+            )
+    # Remove the route
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:
+            print(query,file=psql.stdin)

--- a/imageroot/actions/remove-trunk/30reload_modules
+++ b/imageroot/actions/remove-trunk/30reload_modules
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# If the control reaches this step, reload kamailio modules.
+
+cat << EOF | podman exec -i kamailio kamcmd > /dev/null
+dialplan.reload
+dispatcher.reload
+EOF

--- a/imageroot/actions/remove-trunk/validate-input.json
+++ b/imageroot/actions/remove-trunk/validate-input.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "remove-trunk input",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/remove-trunk-input.json",
+  "description": "Retrieve a trunk",
+  "examples": [
+    {
+      "rule": "05551594XX"
+    }
+  ],
+  "type": "object",
+  "required": ["rule"],
+  "properties": {
+    "rule": {
+      "type": "string",
+      "title": "pattern matching rule",
+      "minLength": 1,
+      "examples": ["05551594XX"]
+    }
+  }
+}

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -279,9 +279,14 @@ route[GET_ASTERISK_NODE] {
     dp_replace(1,"$rd","$var(dispatcher_id)");
     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - dispatcher_id: $var(dispatcher_id) \n");
     if($var(dispatcher_id) == 0 || $var(dispatcher_id) == $null) {
-        # no dispatcher id found, drop the call
-        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - no dispatcher id found, dropping the call \n");
-        return;
+        # checking if it's an inbound trunk call, using dp_replace with 2 as first parameter and ru as second
+        dp_replace(2,"$ru","$var(dispatcher_id)");
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - dispatcher_id: $var(dispatcher_id) \n");
+        if ($var(dispatcher_id) == 0 || $var(dispatcher_id) == $null) {
+            # no dispatcher id found, drop the call
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - no dispatcher id found, dropping the call \n");
+            return;
+        }
     }
     # get the correct node from dispatcher
     ds_select_dst("$var(dispatcher_id)",8);

--- a/modules/postgres/migrations/04_nethvoice-proxy.sql
+++ b/modules/postgres/migrations/04_nethvoice-proxy.sql
@@ -1,6 +1,9 @@
+CREATE TYPE route_type_e AS ENUM ('domain', 'trunk');
+
 CREATE TABLE public.nethvoice_proxy_routes (
     id integer NOT NULL,
-    domain character varying(64) NOT NULL,
+    target character varying(64) NOT NULL,
+    route_type route_type_e NOT NULL,
     setid integer NOT NULL
 );
 

--- a/tests/10_actions/00_add_trunk_validate.robot
+++ b/tests/10_actions/00_add_trunk_validate.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Library   SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Input can't be empty
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {}    rc_expected=10    decode_json=False
+
+Rule is required
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"destination": {"uri": "sip:127.0.0.1:5080", "description": "module1"}}    rc_expected=10    decode_json=False
+
+Destination is required
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule": "05551594XX"}    rc_expected=10    decode_json=False
+
+Rule can't be empty
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"", "destination":{"uri": "sip:127.0.0.1:5080", "description": "module1"}}    rc_expected=10    decode_json=False
+
+Destination can't be empty
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{}}    rc_expected=10    decode_json=False
+
+URI field is required
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"description": "module1"}}    rc_expected=10    decode_json=False
+
+URI field can't be empty
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"uri": "", "description": "module1"}}    rc_expected=10    decode_json=False
+
+Description field is required
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"uri": "sip:127.0.0.1:5080"}}    rc_expected=10    decode_json=False
+
+Description field can't be empty
+    ${response} =  Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"uri": "sip:127.0.0.1:5080", "description": ""}}    rc_expected=10    decode_json=False
+

--- a/tests/10_actions/00_get_trunk_validate.robot
+++ b/tests/10_actions/00_get_trunk_validate.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Library   SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Input can't be empty
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {}    rc_expected=10    decode_json=False
+
+Rule can't be empty
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":""}    rc_expected=10    decode_json=False

--- a/tests/10_actions/00_remove_trunk_validate.robot
+++ b/tests/10_actions/00_remove_trunk_validate.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Library   SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Input can't be empty
+    ${response} =  Run task    module/${module_id}/remove-trunk
+    ...    {}    rc_expected=10    decode_json=False
+
+Rule is required
+    ${response} =  Run task    module/${module_id}/remove-trunk
+    ...    {"destination": {"uri": "sip:127.0.0.1:5080", "description": "module1"}}    rc_expected=10    decode_json=False
+
+Rule can't be empty
+    ${response} =  Run task    module/${module_id}/remove-trunk
+    ...    {"rule":""}    rc_expected=10    decode_json=False

--- a/tests/10_actions/10_trunks_integrations.robot
+++ b/tests/10_actions/10_trunks_integrations.robot
@@ -1,0 +1,64 @@
+*** Settings ***
+Library   SSHLibrary
+Library    Collections
+Library    String
+Resource  ../api.resource
+
+*** Test Cases ***
+Add a new trunk
+    Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"uri":"sip:127.0.0.1:5080","description":"module1"}}
+    Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551595XX", "destination":{"uri":"sip:127.0.0.1:5081","description":"module2"}}
+
+Get info about a non-existing trunk
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551596XX"}
+    Should Be Empty    ${response}
+
+Get info about a trunk
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551594XX"}
+    Should Be Equal    ${response["destination"]}    ${{ {"uri":"sip:127.0.0.1:5080","description":"module1"} }}
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551595XX"}
+    Should be Equal    ${response["destination"]}    ${{ {"uri":"sip:127.0.0.1:5081","description":"module2"} }}
+
+Rewrite a trunk
+    Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551594XX", "destination":{"uri":"sip:127.0.0.1:5060","description":"module3"}}
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551594XX"}
+    Should Be Equal    ${response["destination"]}    ${{ {"uri":"sip:127.0.0.1:5060","description":"module3"} }}
+    Run task    module/${module_id}/add-trunk
+    ...    {"rule":"05551595XX", "destination":{"uri":"sip:127.0.0.1:5084","description":"module4"}}
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551595XX"}
+    Should Be Equal    ${response["destination"]}    ${{ {"uri":"sip:127.0.0.1:5084","description":"module4"} }}
+
+Get list of trunks
+    ${response} =  Run task    module/${module_id}/list-trunks    {}
+    ${list_len} =  Get Length    ${response}
+    Should Be Equal As Numbers    2    ${list_len}
+
+Remove a not existing trunk
+    ${response} =  Run task    module/${module_id}/remove-trunk
+    ...    {"rule":"05551596XX"}
+    Should Be Empty    ${response}
+
+Remove a trunk
+    Run task    module/${module_id}/remove-trunk
+    ...    {"rule":"05551594XX"}
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551594XX"}
+    Should Be Empty    ${response}
+    Run task    module/${module_id}/remove-trunk
+    ...    {"rule":"05551595XX"}
+    ${response} =  Run task    module/${module_id}/get-trunk
+    ...    {"rule":"05551595XX"}
+    Should Be Empty    ${response}
+
+
+List of trunks should be empty
+    ${response} =  Run task    module/${module_id}/list-trunks    {}
+    Should Be Empty    ${response}


### PR DESCRIPTION
When an inbound call arrives, two checks are performed on the `[GET_ASTERISK_NODE]` route:

1. dialplan with `dpid = 1`, where a strict match (`matchop = 0`) is performed, checking the domain part in the request-uri (`$rd`).
1. dialplan with `dpid = 2`, where a regex match (`matchop = 1`) is performed, checking the entire request-uri (`$ru`).

The inbound trunk will match the second check.

Example of a `dialplan` table's row:
```
 id | dpid | pr | match_op |     match_exp     | match_len | subst_exp | repl_exp | attrs 
----+------+----+----------+-------------------+-----------+-----------+----------+-------
  1 |    2 |  1 |        1 | sip:0687159000@.* |         0 | (.*)      | 1        | 1     
  ```