### PR TITLE
Refactor routes actions logic

### DIFF
--- a/imageroot/actions/add-route/20writeroute
+++ b/imageroot/actions/add-route/20writeroute
@@ -35,17 +35,12 @@ if not proxy_route:
                   f'INSERT INTO domain (domain, did) VALUES ( \'{data["domain"]}\', \'{data["domain"]}\');\n'
                   )
 
-# Check if we have to add or modify an addres
-for addres in data["address"]:
-    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'SELECT COALESCE(json_agg(dispatcher.*), \'[]\'::json) FROM dispatcher WHERE destination=\'{addres["uri"]}\' AND setid={proxy_route[0]["setid"]};\n', file=psql.stdin)
-        destination, _ = psql.communicate()
-        destination = json.loads(destination)
+# Cleanup existing route configuration
+query += f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
 
-    if not destination:
+# Create new route configuration
+for addres in data["address"]:
         query += f'INSERT INTO dispatcher (setid,  destination, description) VALUES ({proxy_route[0]["setid"]},\'{addres["uri"]}\',\'{addres["description"]}\');\n'
-    else:
-        query +=  f'UPDATE dispatcher SET description = \'{addres["description"]}\' WHERE id={destination[0]["id"]};\n'
 
 # Write the route
 with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:

--- a/imageroot/actions/remove-route/20removeroute
+++ b/imageroot/actions/remove-route/20removeroute
@@ -20,26 +20,12 @@ with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.en
         proxy_route = json.loads(proxy_route)
 
 if proxy_route:
-    # Remove all the selected address from the route
-    if "address" in data:
-        address_list = ','.join(['\'{}\''.format(addres["uri"]) for addres in data["address"]])
-        with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:
-            print(f'DELETE FROM dispatcher WHERE destination IN ({address_list}) AND setid = {proxy_route[0]["setid"]};\n', file=psql.stdin)
-
-    # Get the length of the address list
-    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as psql:
-        print(f'WITH address AS (SELECT COUNT(*) FROM dispatcher WHERE setid={proxy_route[0]["setid"]}) SELECT JSON_AGG(address.*) FROM address;\n', file=psql.stdin)
-        address, _ = psql.communicate()
-        address = json.loads(address)
-
-    # If the list is empty or the address list is not given, delete the route
-    if address[0]["count"] == 0 or "address" not in data:
-        query = (
-                f'DELETE FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND setid={proxy_route[0]["setid"]} AND route_type=\'domain\';\n'
-                f'DELETE FROM domain WHERE domain=\'{data["domain"]}\' AND did=\'{data["domain"]}\';\n'
-                f'DELETE FROM dialplan WHERE match_exp=\'{data["domain"]}\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
-                f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
-                )
-        # Remove the route
-        with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:
-            print(query,file=psql.stdin)
+    query = (
+            f'DELETE FROM nethvoice_proxy_routes WHERE target=\'{data["domain"]}\' AND setid={proxy_route[0]["setid"]} AND route_type=\'domain\';\n'
+            f'DELETE FROM domain WHERE domain=\'{data["domain"]}\' AND did=\'{data["domain"]}\';\n'
+            f'DELETE FROM dialplan WHERE match_exp=\'{data["domain"]}\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
+            f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
+            )
+    # Remove the route
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]], stdin=subprocess.PIPE, text=True) as psql:
+        print(query,file=psql.stdin)

--- a/imageroot/actions/remove-route/validate-input.json
+++ b/imageroot/actions/remove-route/validate-input.json
@@ -4,11 +4,7 @@
   "$id": "http://schema.nethserver.org/nethvoice-proxy/remove-route-input.json",
   "description": "Remove a VoIP route",
   "examples": [
-    {
-      "domain": "voice.nethserver.org",
-      "address": ["sip:127.0.0.1:5080", "sip:127.0.0.1:5081"]
-    },
-    {
+        {
       "domain": "voice.nethserver.org"
     }
   ],
@@ -22,26 +18,6 @@
       "format": "idn-hostname",
       "minLength": 1,
       "examples": ["voice.nethserver.org"]
-    },
-    "address": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "required": ["uri", "description"],
-        "properties": {
-          "uri": {
-            "type": "string",
-            "minLength": 1
-          },
-          "description": {
-            "type": "string",
-            "title": "Description of the destination, can be used for store the NethVoice module ID/UUID"
-          }
-        }
-      },
-      "title": "Backend Asterisk",
-      "description": "A list of Asterisk URI."
     }
   }
 }

--- a/tests/10_actions/00_remove_route_validate.robot
+++ b/tests/10_actions/00_remove_route_validate.robot
@@ -7,16 +7,6 @@ Input can't be empty
     ${response} =  Run task    module/${module_id}/remove-route
     ...    {}    rc_expected=10    decode_json=False
 
-Domain is required
-    ${response} =  Run task    module/${module_id}/remove-route
-    ...    {"address": [{"uri": "sip:127.0.0.1:5080", "description": "module1"}]}    rc_expected=10    decode_json=False
-
 Domain can't be empty
-    ${response} =  Run task    module/${module_id}/remove-route
-    ...    {"domain":"", "address": [{"uri": "sip:127.0.0.1:5080", "description": "module1"}]}    rc_expected=10    decode_json=False
     ${response} =  Run task    module/${module_id}/add-route
     ...    {"doamin":""}    rc_expected=10    decode_json=False
-
-Address list can't be empty
-    ${response} =  Run task    module/${module_id}/remove-route
-    ...    {"domain":"ns8.test", "address":[]}    rc_expected=10    decode_json=False

--- a/tests/10_actions/10_routes_integrations.robot
+++ b/tests/10_actions/10_routes_integrations.robot
@@ -14,19 +14,29 @@ Add a new route
 
 Add a new addres to an existing route
     Run task    module/${module_id}/add-route
-    ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
+    ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5080","description":"module1"},{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
     ${response} =  Run task    module/${module_id}/get-route
     ...    {"domain":"ns8.test"}
+    Length Should Be    ${response["address"]}    2
     Should Contain    ${response["address"]}    ${{ {"uri":"sip:127.0.0.1:5080","description":"module1"} }}
     Should Contain    ${response["address"]}    ${{ {"uri":"sip:127.0.0.1:5081","description":"module2"} }}
 
 Remove an addres from an existing route
-    Run task    module/${module_id}/remove-route
-    ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
+    Run task    module/${module_id}/add-route
+    ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5080","description":"module1"}]}
     ${response} =  Run task    module/${module_id}/get-route
     ...    {"domain":"ns8.test"}
+    Length Should Be    ${response["address"]}    1
     Should Contain    ${response["address"]}    ${{ {"uri":"sip:127.0.0.1:5080","description":"module1"} }}
     Should Not Contain    ${response["address"]}    ${{ {"uri":"sip:127.0.0.1:5081","description":"module2"} }}
+
+Ovveride an existing route
+     Run task    module/${module_id}/add-route
+    ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5082","description":"module3"}]}
+    ${response} =  Run task    module/${module_id}/get-route
+    ...    {"domain":"ns8.test"}
+    Length Should Be    ${response["address"]}    1
+    Should Contain    ${response["address"]}    ${{ {"uri":"sip:127.0.0.1:5082","description":"module3"} }}
 
 Remove a route
     Run task    module/${module_id}/remove-route
@@ -35,27 +45,13 @@ Remove a route
     ...    {"domain":"ns8.test"}
     Should Be Empty    ${response}
 
-Remove all address from a route
-    Run task    module/${module_id}/add-route
-    ...    {"domain":"ns8.test2", "address":[{"uri":"sip:127.0.0.1:5080","description":"module1"}]}
-    Run task    module/${module_id}/add-route
-    ...    {"domain":"ns8.test2", "address":[{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
-    Run task    module/${module_id}/remove-route
-    ...    {"domain":"ns8.test2", "address":[{"uri":"sip:127.0.0.1:5080","description":"module1"}]}
-    Run task    module/${module_id}/remove-route
-    ...    {"domain":"ns8.test2", "address":[{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
-    ${response} =  Run task    module/${module_id}/get-route
-    ...    {"domain":"ns8.test2"}
-    Should Be Empty    ${response}
-
 Get list of routes
     Run task    module/${module_id}/add-route
     ...    {"domain":"ns8.test", "address":[{"uri":"sip:127.0.0.1:5080","description":"module1"}]}
     Run task    module/${module_id}/add-route
     ...    {"domain":"ns8.test1", "address":[{"uri":"sip:127.0.0.1:5081","description":"module2"}]}
     ${response} =  Run task    module/${module_id}/list-routes    {}
-    ${list_len} =  Get Length    ${response}
-    Should Be Equal As Numbers    2    ${list_len}
+    Length Should Be     ${response}    2
 
 Get info about a route
     ${response} =  Run task    module/${module_id}/get-route


### PR DESCRIPTION
Right now, the route actions can also be used to manipulate a route's
destination, add/remove more addresses, or change the description of an
address. 
However, this behavior is not so easy to use and can lead to
unexpected behaviors, like reconfiguring the NethVoice module and ending up
with a route with two destination addresses (the old and the new one).

This PR makes the action idempotent, so `add-route` will always rewrite the
route, and `remove-route` will always delete the route.
