### PR TITLE
systemd: ignore image volumes on `redis` service

### DIFF
--- a/imageroot/systemd/user/redis.service
+++ b/imageroot/systemd/user/redis.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --publish=127.0.0.1:${REDIS_PORT}:6379 \
     --replace --name=%N \
+    --image-volume=ignore \
     ${NETHVOICE_PROXY_REDIS_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/redis.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/redis.ctr-id


### PR DESCRIPTION
The `/data` volume defined in the upstream `redis` image is not used and it creates an orphanage anonymous volume every service restart. Also, anonymous volumes are not supported by the NS8 move/clone procedure.

https://github.com/nethesis/ns8-nethvoice/issues/171