### PR TITLE
publicAddress. Fixed missing input data in case of wrong fqdn

### DIFF
--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -223,6 +223,8 @@ export default {
               config.addresses.public_address || this.ipAddressPersonal;
           } else {
             this.ipAddressPersonal = null;
+            this.address =
+              config.addresses.public_address || this.ipAddressPersonal;
           }
         })
         .catch((error) => {


### PR DESCRIPTION
Public Ip Address now populate with address -> public_address data also if proxy domain field is not solvable
