### PR TITLE
modules: update kamailio to version `5.8.2`

### DIFF
--- a/modules/kamailio/Dockerfile
+++ b/modules/kamailio/Dockerfile
@@ -6,7 +6,7 @@ ENV REFRESHED_AT 2024-04-24
 ENV TZ="Europe/Rome"
 
 ENV DEBIAN_FRONTEND="noninteractive"
-ENV KAMAILIO_VERSION="5.8.1"
+ENV KAMAILIO_VERSION="5.8.2"
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install --assume-yes gnupg wget
 RUN echo "deb http://deb.kamailio.org/kamailio58 focal main" > /etc/apt/sources.list.d/kamailio.list


### PR DESCRIPTION
Fix for https://github.com/nethesis/ns8-nethvoice-proxy/actions/runs/9482763901/job/26128427426#step:4:418
```
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0830140Z E: Version '5.8.1+ubuntu20.04' for 'kamailio' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0831562Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-autheph-modules' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0833112Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-berkeley-bin' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0834570Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-berkeley-modules' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0835805Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-cnxcc-modules' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0836678Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-cpl-modules' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0837457Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-dbg' was not found
publish-images / Publish module images	Run # Build the module images	2024-06-12T12:44:14.0838342Z E: Version '5.8.1+ubuntu20.04' for 'kamailio-erlang-modules' was not found
```
