### PR TITLE
Fix move and clone proceure

### DIFF
--- a/imageroot/actions/clone-module/09stop_services
+++ b/imageroot/actions/clone-module/09stop_services
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+systemctl --user stop kamailio.service postgres.service

--- a/imageroot/actions/clone-module/91set_postgres_password
+++ b/imageroot/actions/clone-module/91set_postgres_password
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Loop for 30 seconds until the database is ready
+for i in {1..30}; do
+    if podman exec -e PGCONNECT_TIMEOUT=2 postgres psql -U $POSTGRES_USER $POSTGRES_DB -c "SELECT 1;" &> /dev/null; then
+	break
+    fi
+    sleep 1
+done
+
+# Set the password for the postgres user
+podman exec postgres psql -U $POSTGRES_USER $POSTGRES_DB -c "ALTER USER \"$POSTGRES_USER\" WITH PASSWORD '$POSTGRES_PASSWORD';" &> /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "Failed to set the password for the postgres user"
+    exit 1
+fi

--- a/imageroot/actions/create-module/80start_service
+++ b/imageroot/actions/create-module/80start_service
@@ -7,4 +7,4 @@
 
 # If the control reaches this step, the service can be enabled and started
 
-systemctl --user enable --now kamailio.service
+systemctl --user enable --now kamailio.service postgres.service

--- a/imageroot/actions/transfer-state/49stop_services
+++ b/imageroot/actions/transfer-state/49stop_services
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+systemctl --user stop kamailio.service postgres.service

--- a/imageroot/systemd/user/postgres.service
+++ b/imageroot/systemd/user/postgres.service
@@ -21,3 +21,6 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postgres.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postgres.ctr-id
 PIDFile=%t/postgres.pid
 Type=forking
+
+[Install]
+WantedBy=default.target

--- a/modules/kamailio/bootstrap.sh
+++ b/modules/kamailio/bootstrap.sh
@@ -67,7 +67,14 @@ echo -n '$PKG_MEM is: ' ; echo "${PKG_MEM}"
 echo -n '$ENVIRONMENT is: ' ; echo "${ENVIRONMENT}"
 
 # Run kamailio
-$kamailio -f $PATH_KAMAILIO_CFG -m "${SHM_MEM}" -M "${PKG_MEM}" -DD -E -e
+if [ -f "/tmp/dev" ] || [ "${ENV}" == "dev" ]; then
+    echo "Dev mode!"
+    $kamailio -f $PATH_KAMAILIO_CFG -m "${SHM_MEM}" -M "${PKG_MEM}" -DD -E -e
+else
+    #Allow kamailio to handle SIGTERM from podman stop
+    exec $kamailio -f $PATH_KAMAILIO_CFG -m "${SHM_MEM}" -M "${PKG_MEM}" -DD -E -e
+fi
+
 while [ -f "/tmp/dev" ] || [ "${ENV}" == "dev" ]
   do
     echo "Dev mode!"


### PR DESCRIPTION
To ensure that the move/clone procedure is performed correctly, this PR makes sure that the following tasks are done:

* Ensure that the relevant services are properly stopped during the container volume transfer.
* Set the new password for the `postgres` PostgreSQL DB user.

After the clone/move, the module **must** be reconfigured via `configure-module` to be fully operational.

https://github.com/nethesis/ns8-nethvoice/issues/210