### PR TITLE
No audio after UPDATE packages behind NAT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ run-rtpengine-dev:
 	podman rm rtpengine || exit 0
 	podman run -d --name rtpengine --env-file ~/.config/state/environment --network=host \
 		-v ./modules/rtpengine/files/rtpengine.conf.template:/src/rtpengine.conf.template:z \
+		-v ./modules/rtpengine/bootstrap.sh:/bootstrap.sh:z \
 		ghcr.io/nethesis/nethvoice-proxy-rtpengine:$(TAG)
 
 log:

--- a/imageroot/actions/configure-module/10validate_local_networks
+++ b/imageroot/actions/configure-module/10validate_local_networks
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import ipaddress
+import os
+import agent
+
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+
+def is_cidr_format(ip_str):
+    try:
+        ipaddress.IPv4Network(ip_str)
+        return True
+    except ValueError:
+        return False
+
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+if "local_networks" in data:
+    local_network = ""
+    try:
+        for local_network in data["local_networks"]:
+            ipaddress.IPv4Network(local_network)
+    except ValueError:
+        agent.set_status('validation-failed')
+        json.dump([{'field':'service_networks','value': local_network,'error':'local_network_netmask_is_not_valid'}], fp=sys.stdout)
+        sys.exit(3)

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -13,6 +13,8 @@ import os
 
 data = json.load(sys.stdin)
 
+local_networks = set()
+
 if "addresses" in data:
 
     address = data["addresses"]
@@ -23,11 +25,16 @@ if "addresses" in data:
         agent.set_env("PUBLIC_IP", address["address"])
         agent.set_env("PRIVATE_IP", "")
         agent.set_env("BEHIND_NAT", "false")
+        agent.unset_env("LOCALNETWORKS")
     else:
         # if there's a public address, the proxy is behind NAT
         agent.set_env("PUBLIC_IP", address["public_address"])
         agent.set_env("PRIVATE_IP", address["address"])
         agent.set_env("BEHIND_NAT", "true")
+
+        # Get local network from routing table (excluding default route)
+        local_networks.add(os.popen("ip route | grep -v default | grep 'src " + address["address"] + "' | awk '{print $1}'").read().strip())
+        agent.set_env("LOCALNETWORKS", list(local_networks)[0])
 
     agent.set_env("DEFAULT_CONTACT", address["address"] + ":5060" if "public_address" not in address else address["public_address"] + ":5060")
 
@@ -35,6 +42,12 @@ if "service_net" in data:
     service = data["service_net"]
     agent.set_env("SERVICE_IP", service["address"])
     agent.set_env("SERVICE_NET", service["netmask"])
+
+#check if local_networks is not empty and local_networks filed is present in data
+if local_networks and "local_networks" in data:
+    # Add extra local networks
+    local_networks.update(set(data["local_networks"]))
+    agent.set_env("LOCALNETWORKS", ",".join(local_networks))
 
 if "fqdn" in data:
     # Check if previous fqdn is different from new one

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -59,6 +59,14 @@
           "type": "string"
         }
       }
+    },
+    "local_networks": {
+      "title": "Local networks",
+      "type": "array",
+      "items": {
+        "title": "Netmask of the local network",
+        "type": "string"
+      }
     }
   }
 }

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -33,4 +33,6 @@ config["fqdn"] = os.environ["KML_DEFAULT_FQDN"]
 
 config["service_network"] = service_network
 
+config["local_networks"] = os.environ["LOCALNETWORKS"].split(",") if os.getenv("LOCALNETWORKS") else []
+
 json.dump(config, fp=sys.stdout)

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -57,6 +57,14 @@
           "type": "string"
         }
       }
+    },
+    "local_networks": {
+      "title": "Local networks",
+      "type": "array",
+      "items": {
+        "title": "Netmask of the local network",
+        "type": "string"
+      }
     }
   }
 }

--- a/imageroot/systemd/user/kamailio.service
+++ b/imageroot/systemd/user/kamailio.service
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/podman run \
     --env=SERVICE_IP \
     --env=SERVICE_NET \
     --env=BEHIND_NAT \
+    --env=LOCALNETWORKS \
     --detach \
     --conmon-pidfile=%t/kmalio.pid \
     --cidfile=%t/kmalio.ctr-id \

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -191,17 +191,20 @@ request_route {
     route(HEALTHCHECK);
     # manage dialog module
     dlg_manage();
-    if (is_in_subnet($si, INTERNAL_NETWORK) || $si == "127.0.0.1" ) {
-        $avp(direction) = "out";
-    } else {
-        $avp(direction) = "in";
+    if (!is_method("UPDATE")){
+        if (is_in_subnet($si, INTERNAL_NETWORK) || $si == "127.0.0.1" ) {
+            $avp(direction) = "out";
+        } else {
+            $avp(direction) = "in";
+        }
+            if ($avp(direction) == "in") {
+                # NAT detection
+                route(NATDETECT);
+            }
+            $dlg_var(direction) = $avp(direction);
+            $dlg_var(source_ip) = $si; // saving source IP for correct handling socket for reply
     }
-    if ($avp(direction) == "in") {
-        # NAT detection
-        route(NATDETECT);
-    }
-    $dlg_var(direction) = $avp(direction);
-    $dlg_var(source_ip) = $si; // saving source IP for correct handling socket for reply
+    
     # CANCEL processing
     if (is_method("CANCEL")) {
         if (t_check_trans()) {

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -201,6 +201,7 @@ request_route {
         route(NATDETECT);
     }
     $dlg_var(direction) = $avp(direction);
+    $dlg_var(source_ip) = $si; // saving source IP for correct handling socket for reply
     # CANCEL processing
     if (is_method("CANCEL")) {
         if (t_check_trans()) {
@@ -507,12 +508,12 @@ route[NATMANAGE] {
     xlog('L_WARN', "[DEV] - $ci $rm-$cs - direction: $avp(direction) / $dlg_var(direction) ($rs) \n");
     if ((($avp(direction) == 'in' || $dlg_var(direction) == 'in') && is_request()) || (($avp(direction) == 'out' || $dlg_var(direction) == 'out') && is_reply()) ) {
         if (has_body("application/sdp")) {
-            $var(rtpengine_conf) = "external internal " + $var(rtpengine_conf);
+            $var(rtpengine_conf) = "direction=external direction=internal " + $var(rtpengine_conf);
             if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - external - internal (rs: $rs)\n");
         }
     } else {
         if (has_body("application/sdp")) {
-            $var(rtpengine_conf) = "internal external " + $var(rtpengine_conf);
+            $var(rtpengine_conf) = "direction=internal direction=external " + $var(rtpengine_conf);
             if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - internal - external (rs: $rs)\n");
         }
     }
@@ -583,6 +584,7 @@ route[NATMANAGE] {
     }
 
     if ($shv(rtpengine) == 't') {
+        route(SET_SOCKET);
         # Adding loog protection and ICE removing
         $var(rtpengine_conf) = "" + $var(rtpengine_conf) + " ICE=remove";
         if (nat_uac_test("8")) {
@@ -925,3 +927,50 @@ route[HANDLE_ALIAS] {
     }
 
 } # end of route[HANDLE_ALIAS]
+
+# -----------------------------------------------------------------------------
+# route[SET_FROM_SOCKET]
+# this route set the from socket accoding also to LOCALNETWORKS
+# -----------------------------------------------------------------------------
+route[SET_SOCKET] {
+    if( $shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in SET_SOCKET route \n");
+    if(is_request()) {
+        # print $rd is an ip and is in LOCALNETWORKS then print it
+        $var(destination_ip)= $null; # reinitialize the variable
+        $var(destination_ip) = $(ru{uri.host}); # fetch the destination ip from ru
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip: $var(destination_ip) \n");
+        if ($var(destination_ip) != $null && $var(destination_ip) != 0 && $var(destination_ip) != "") {
+            if (is_in_subnet($var(destination_ip), LOCALNETWORKS)) {
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip is in LOCALNETWORKS \n");
+                $var(from_socket) = PRIVATE_IP;
+                set_advertised_address(PRIVATE_IP);
+                # logging I've set the PRIVATE IP
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from_socket: $var(from_socket) \n");
+                # handling rtpengine manage
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
+                # replace external in $var(rtpengine_conf) with local
+                $var(rtpengine_conf) = $(var(rtpengine_conf){s.replace,external,local});
+                # logging rtpengine_conf
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
+            }
+        }
+    } else {
+        if(is_reply()){
+            $var(destination_ip)= $null; # reinitialize the variable
+            # logging $dlg_var(source_ip)
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Original source ip: $dlg_var(source_ip) \n");
+            # fetching destination ip from contact
+            $var(destination_ip) = $dlg_var(source_ip);
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip: $var(destination_ip) \n");
+            if ($var(destination_ip) != $null && $var(destination_ip) != 0 && $var(destination_ip) != "") {
+                if (is_in_subnet($var(destination_ip), LOCALNETWORKS)) {
+                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip is in LOCALNETWORKS \n");
+                    # replace external in $var(rtpengine_conf) with local
+                    $var(rtpengine_conf) = $(var(rtpengine_conf){s.replace,external,local});
+                    # logging rtpengine_conf
+                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
+                }
+            }
+        }
+    }
+}

--- a/modules/kamailio/config/template.kamailio-local.cfg
+++ b/modules/kamailio/config/template.kamailio-local.cfg
@@ -47,6 +47,8 @@
 #!define KML_UA_HEADER "${KML_UA_HEADER}"
 #!define DEFAULT_CONTACT "${DEFAULT_CONTACT}"
 #!define WITH_TLS
+#!define LOCALNETWORKS "${LOCALNETWORKS}"
+#!define PRIVATE_IP "${PRIVATE_IP}"
 ##!define WITH_SIPTRACE
 
 server_header="Server: ${KML_SERVER_HEADER}"

--- a/modules/rtpengine/bootstrap.sh
+++ b/modules/rtpengine/bootstrap.sh
@@ -2,7 +2,7 @@
 
 # generating ${INTERFACE_SECTION} depending on the value of ${BEHIND_NAT}
 if [ "${BEHIND_NAT}" == "true" ]; then
-    export INTERFACE_SECTION="interface=internal/${SERVICE_IP};external/${PRIVATE_IP}!${PUBLIC_IP}"
+    export INTERFACE_SECTION="interface=local/${PRIVATE_IP};internal/${SERVICE_IP};external/${PRIVATE_IP}!${PUBLIC_IP}"
 else
     export INTERFACE_SECTION="interface=internal/${SERVICE_IP};external/${PUBLIC_IP}"
 fi

--- a/tests/00_nethvoice-proxy_add-module.robot
+++ b/tests/00_nethvoice-proxy_add-module.robot
@@ -20,9 +20,11 @@ Gather system information
 
     FOR    ${interface}    IN    @{response['data']}
         ${address}=    Set Variable    ${interface['addresses'][0]['address']}
+        ${network}=    Set Variable    ${interface['addresses'][0]['network']}
         EXIT FOR LOOP IF    "${interface['name']}" == "eth0"
     END
     Set Global Variable    ${local_ip}    ${address}
+    Set Global Variable    ${local_network}   ${network}
 
 Check if nethvoice-proxy is configured wih the correctly default values
     ${response} =  Run task    module/${module_id}/list-service-providers

--- a/tests/10_actions/00_configure_module_validate.robot
+++ b/tests/10_actions/00_configure_module_validate.robot
@@ -35,3 +35,7 @@ Service network's address and netmask must be valid
     ...    {"addresses": {"address": "127.0.0.1"}, "service_network": {"address": "A", "netmask": "10.5.4.0/24"}}    rc_expected=10    decode_json=False
     ${response} =  Run task    module/${module_id}/configure-module
     ...    {"addresses": {"address": "127.0.0.1"}, "service_network": {"address": "10.5.4.1", "netmask": "A"}}    rc_expected=2    decode_json=False
+
+Networks in local networks list must be valid
+    ${response} =  Run task    module/${module_id}/configure-module
+    ...    {"local_networks": ["A"]}    rc_expected=3    decode_json=False

--- a/tests/10_actions/00_get_configuration_validate.robot
+++ b/tests/10_actions/00_get_configuration_validate.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Library   SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Get default configuration
+    ${response} =  Run task    module/${module_id}/get-configuration
+    ...    {}    rc_expected=0

--- a/tests/10_actions/10_configure_integrations.robot
+++ b/tests/10_actions/10_configure_integrations.robot
@@ -11,6 +11,7 @@ Set an address
     ${response} =  Run task    module/${module_id}/get-configuration
     ...    {}
     Should Be Equal   ${response["addresses"]}    ${{ {"address": "${local_ip}"} }}
+    Should Be Empty   ${response['local_networks']}
    ${response} =  Run task    module/${module_id}/list-service-providers
     ...    {"service": "sip", "transport": "tcp", "filter": {"module_id": "${module_id}"} }
     Should Be Equal    ${response[0]['address']}    ${local_ip}
@@ -20,10 +21,12 @@ Set an address
 
 Set an address behind NAT
     Run task    module/${module_id}/configure-module
-    ...    {"addresses": {"address": "${local_ip}", "public_address": "1.2.3.4"}}
+    ...    {"addresses": {"address": "${local_ip}", "public_address": "1.2.3.4"}, "local_networks": ["10.20.30.0/24"]}
     ${response} =  Run task    module/${module_id}/get-configuration
     ...    {}
     Should Be Equal   ${response["addresses"]}    ${{ {"address": "${local_ip}", "public_address": "1.2.3.4"} }}
+    Should Contain Match   ${response['local_networks']}   ${local_network}
+    Should Contain Match   ${response['local_networks']}   10.20.30.0/24
    ${response} =  Run task    module/${module_id}/list-service-providers
     ...    {"service": "sip", "transport": "tcp", "filter": {"module_id": "${module_id}"} }
     Should Be Equal    ${response[0]['address']}    ${local_ip}


### PR DESCRIPTION
Audio get routed to the wrong address when Asterisk send an UPDATE packet while being behind a NAT.

In this scenario, the UPDATE packets were inadvertently modifying dlg_var(direction) variable within Kamailio. This variable is used to track the direction of the media flow (RTP packets) and is integral to the business logic that manages media handling through rtpengine_manage.

When dlg_var(direction) was altered by the UPDATE packets, it caused inconsistencies in how media flow direction was being handled, leading to disruptions in the call handling process. Essentially, the logic that determined the direction of RTP streams was getting confused, which could result in issues like incorrect media routing and dropped calls after 30 seconds.

https://evoseed.atlassian.net/servicedesk/customer/portal/5/EA-29