### PR TITLE
Refactor environment variable handling in create-module and services

### DIFF
--- a/imageroot/actions/clone-module/91set_postgres_password
+++ b/imageroot/actions/clone-module/91set_postgres_password
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# sourcing the file directly is broken with quotes
+POSTGRES_PASSWORD=$(grep '^POSTGRES_PASSWORD=' ./passwords.env) && export $POSTGRES_PASSWORD
+
 # Loop for 30 seconds until the database is ready
 for i in {1..30}; do
     if podman exec -e PGCONNECT_TIMEOUT=2 postgres psql -U $POSTGRES_USER $POSTGRES_DB -c "SELECT 1;" &> /dev/null; then

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -14,7 +14,13 @@ tcp_ports = os.environ["TCP_PORTS"].split(',')
 
 agent.set_env('ENV', 'prod')
 agent.set_env('POSTGRES_USER', 'postgres')
-agent.set_env('POSTGRES_PASSWORD', uuid.uuid4())
+
+#POSTGRES_PASSWORD written to passwords.env
+password = {
+    "POSTGRES_PASSWORD": uuid.uuid4()
+}
+agent.write_envfile("passwords.env", password)
+
 agent.set_env('POSTGRES_HOST', '127.0.0.1')
 agent.set_env('POSTGRES_PORT', tcp_ports[0])
 agent.set_env('POSTGRES_DB', 'kamailio')

--- a/imageroot/systemd/user/kamailio.service
+++ b/imageroot/systemd/user/kamailio.service
@@ -11,6 +11,7 @@ Restart=always
 ExecStartPre=/bin/rm -f %t/kmalio.pid %t/kmalio.ctr-id
 ExecStartPre=-runagent install-certificates
 ExecStart=/usr/bin/podman run \
+    --env-file=%S/state/passwords.env \
     --env=ENV \
     --env=PUBLIC_IP \
     --env=PRIVATE_IP \

--- a/imageroot/systemd/user/postgres.service
+++ b/imageroot/systemd/user/postgres.service
@@ -8,6 +8,7 @@ WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/postgres.pid %t/postgres.ctr-id
 ExecStart=/usr/bin/podman run \
+    --env-file=%S/state/passwords.env \
     --env='POSTGRES_*' \
     --detach \
     --conmon-pidfile=%t/postgres.pid \

--- a/imageroot/update-module.d/10env
+++ b/imageroot/update-module.d/10env
@@ -24,3 +24,12 @@ if os.getenv("SERVICE_IP", None) is None:
     # Clean up obsolete env variable
     agent.unset_env('KML_INTERNAL_NETWORK')
 
+# test if the passwords.env is present and if 'POSTGRES_PASSWORD' is present
+if not os.path.exists("passwords.env") and os.getenv('POSTGRES_PASSWORD') is not None:
+        # create the passwords.env file
+        agent.write_envfile("passwords.env", {
+                "POSTGRES_PASSWORD": os.environ['POSTGRES_PASSWORD']
+        })
+
+        # unset the POSTGRES_PASSWORD
+        agent.unset_env('POSTGRES_PASSWORD')


### PR DESCRIPTION
This pull request refactors the handling of environment variables in the create-module script and the kamailio and postgres services.In the `create-module` script, the `POSTGRES_PASSWORD` is now written to the `passwords.env` file instead of being generated with `uuid.uuid4()`. The kamailio and postgres services now use the `--env-file` flag to read the environment variables from the `passwords.env` file.

just for a build purpose kamailo has been updated 

https://github.com/NethServer/dev/issues/7011