### PR TITLE
destroy-module: don't fail on firewall step

### DIFF
--- a/imageroot/actions/destroy-module/20firewall
+++ b/imageroot/actions/destroy-module/20firewall
@@ -8,5 +8,4 @@
 import os
 import agent
 
-agent.assert_exp(agent.remove_public_service(os.environ['MODULE_ID']))
-
+agent.remove_public_service(os.environ['MODULE_ID'])


### PR DESCRIPTION
If the module removal process fails after the firewall removal step, subsequent retries to remove the module will fail because the service was already removed.