### PR TITLE
Enable SIP tracing on support session events

### DIFF
--- a/imageroot/events/support-session-started/10enable_siptrace
+++ b/imageroot/events/support-session-started/10enable_siptrace
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+podman exec kamailio kamcmd siptrace.status on 

--- a/imageroot/events/support-session-stopped/10disable_siptrace
+++ b/imageroot/events/support-session-stopped/10disable_siptrace
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+podman exec kamailio kamcmd siptrace.status off 

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -99,9 +99,7 @@ loadmodule "http_async_client.so"
 loadmodule "acc.so"
 loadmodule "uac.so"
 loadmodule "sdpops.so"
-#!ifdef WITH_SIPTRACE
 loadmodule "siptrace.so"
-#!endif
 
 
 # -----------------------------------------------------------------------------
@@ -167,15 +165,13 @@ modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")
 #!endif
-#!ifdef WITH_SIPTRACE
 modparam("siptrace", "trace_mode", 1)
 modparam("siptrace", "trace_to_database", 0)
-modparam("siptrace", "trace_on", 1)
+modparam("siptrace", "trace_on", 0)
 modparam("siptrace", "duplicate_uri", "sip:127.0.0.1:5065")
 modparam("siptrace", "hep_mode_on", 1)
 modparam("siptrace", "hep_version", 2)
 modparam("siptrace", "hep_capture_id", 1)
-#!endif
 
 # -----------------------------------------------------------------------------
 # Routing Logic

--- a/modules/kamailio/config/template.kamailio-local.cfg
+++ b/modules/kamailio/config/template.kamailio-local.cfg
@@ -49,7 +49,6 @@
 #!define WITH_TLS
 #!define LOCALNETWORKS "${LOCALNETWORKS}"
 #!define PRIVATE_IP "${PRIVATE_IP}"
-##!define WITH_SIPTRACE
 
 server_header="Server: ${KML_SERVER_HEADER}"
 user_agent_header="User-Agent: ${KML_UA_HEADER}"


### PR DESCRIPTION
Trigger `kamcmd siptrace.status on` in the Kamailio container
when the `support-session-started` event is fired by NethServer 8.
Conversely, run `kamcmd siptrace.status off` on the
`support-session-stopped` event to disable SIP tracing.

### What
This pull request introduces dynamic control over Kamailio SIP 
tracing based on the state of support sessions, allowing the 
command `kamcmd siptrace.status on` to be executed when a 
support session starts and `kamcmd siptrace.status off` when it 
stops.

### Why
By enabling SIP tracing specifically during active support 
sessions, we can capture necessary TLS debug information without 
overloading the system with traces outside of these sessions. This 
improves both performance and debugging efficiency by limiting the 
trace data to relevant periods.

https://github.com/NethServer/dev/issues/7098