### PR TITLE
Update 20firewall

### DIFF
--- a/imageroot/actions/destroy-module/20firewall
+++ b/imageroot/actions/destroy-module/20firewall
@@ -8,5 +8,4 @@
 import os
 import agent
 
-agent.assert_exp(agent.remove_public_service(os.environ['MODULE_ID']))
-
+agent.remove_public_service(os.environ['MODULE_ID'])


### PR DESCRIPTION
Ignore the remote call exit status. If the service is already removed or fails to be removed the destroy-module action must not abort.