### PR TITLE
Update @nethserver/ns8-ui-lib and add mark.js dependency

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^1.0.3",
+    "@nethserver/ns8-ui-lib": "^1.2.1",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^6.2.2",
+    "mark.js": "^8.11.1",
     "prettier": "^2.2.1",
     "sass-loader": "^10.1.1",
     "vue-template-compiler": "^2.6.11"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^0.1.22":
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.22.tgz#07172f7d26931995a75c4f483fa6965861f12061"
-  integrity sha512-gHDI45YnUcHauVfsvvGRB8OrZUtHw4GItojROHKghpbbTaKQXmxefabz7CcGUiyjZfUYtkTmGsGsPQAroOQDgQ==
+"@nethserver/ns8-ui-lib@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.2.1.tgz#1c44f886af63cb8bfbd4fb07ef72163cb3ac5ecf"
+  integrity sha512-vcAFwsDHpTU2jE1Rc9avl22gE7rokGf1nIPzqAynywfuyaa6djzSnP61lJSDHTKQ3oFAd5bzi68McPntLQNAHQ==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5741,6 +5741,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+mark.js@^8.11.1:
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/mark.js/-/mark.js-8.11.1.tgz#180f1f9ebef8b0e638e4166ad52db879beb2ffc5"
+  integrity sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.npmmirror.com/md5.js/download/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
This pull request updates the @nethserver/ns8-ui-lib package to version 1.2.1
and introduces mark.js (version 8.11.1) as a new dependency. 

The updates include:
- Upgrading @nethserver/ns8-ui-lib from 0.1.22 to 1.2.1 in package.json and
  yarn.lock.
- Adding mark.js to package.json and yarn.lock.
