### PR TITLE
fix(kamailio.cfg): Log rejected INVITES or REGISTER for unrecognized …

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -180,7 +180,7 @@ request_route {
     $var(destinationXavp) = "";
     #checking if it's for me
     if (uri!=myself && is_method("INVITE|REGISTER") && !ds_is_from_list() && !has_totag()) {
-        xlog('L_INFO', "[DEV] - $ci $rm-$cs - request not for me, rejecting! \n");
+        xlog('L_WARN', "[DEV] - $ci $rm-$cs - request not for me, rejecting! \n");
         #sl_send_reply("404","Not here");
         exit;
     }


### PR DESCRIPTION
…destination

L_INFO isn't shown by default and this message is helpful to debug problems with trunks