### PR TITLE
fix(kamailio): use shv(debug) for debug logging

### DIFF
--- a/modules/kamailio/Dockerfile
+++ b/modules/kamailio/Dockerfile
@@ -6,7 +6,7 @@ ENV REFRESHED_AT 2024-04-24
 ENV TZ="Europe/Rome"
 
 ENV DEBIAN_FRONTEND="noninteractive"
-ENV KAMAILIO_VERSION="5.8.5"
+ENV KAMAILIO_VERSION="5.8.6"
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install --assume-yes gnupg wget
 RUN echo "deb http://deb.kamailio.org/kamailio58 focal main" > /etc/apt/sources.list.d/kamailio.list

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -160,7 +160,7 @@ modparam("keepalive", "ping_from", PING_FROM)
 modparam("keepalive", "delete_counter", 5)
 modparam("http_async_client", "workers", 2)
 modparam("uac", "restore_dlg", 1)
-modparam("pv", "shvset", "debug=i:1")
+modparam("pv", "shvset", "debug=i:0")
 modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")
@@ -180,7 +180,7 @@ request_route {
     $var(destinationXavp) = "";
     #checking if it's for me
     if (uri!=myself && is_method("INVITE|REGISTER") && !ds_is_from_list() && !has_totag()) {
-        xlog('L_WARN', "[DEV] - $ci $rm-$cs - request not for me, rejecting! \n");
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - request not for me, rejecting! \n");
         #sl_send_reply("404","Not here");
         exit;
     }
@@ -508,7 +508,7 @@ route[NATMANAGE] {
     # defining external > internal or internal > external
     # -------------------------------------------------------------------------------------------------------------------------
     # logging direction
-    xlog('L_WARN', "[DEV] - $ci $rm-$cs - direction: $avp(direction) / $dlg_var(direction) ($rs) \n");
+    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - direction: $avp(direction) / $dlg_var(direction) ($rs) \n");
     if ((($avp(direction) == 'in' || $dlg_var(direction) == 'in') && is_request()) || (($avp(direction) == 'out' || $dlg_var(direction) == 'out') && is_reply()) ) {
         if (has_body("application/sdp")) {
             $var(rtpengine_conf) = "direction=external direction=internal " + $var(rtpengine_conf);
@@ -713,7 +713,7 @@ onreply_route[MANAGE_REPLY] {
         if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in reply route (MANAGE_REPLY) and Response code is: $rs \n");
         # handling avp and dlg_var direction
         # printing $si 
-        xlog('L_WARN', "[DEV] - $ci $rm-$cs - si: $si, rs: $rs \n");
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - si: $si, rs: $rs \n");
         # $si is correctly set, to 10.5.4.1
         # setting direction in opposite (as it's a reply)
         if (is_in_subnet($si, INTERNAL_NETWORK) || $si == "127.0.0.1" ) {
@@ -722,7 +722,7 @@ onreply_route[MANAGE_REPLY] {
             $avp(direction) = "out";
         }
         $dlg_var(direction) = $avp(direction);
-        xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
         
         route(NATMANAGE);
     }
@@ -734,7 +734,7 @@ onreply_route[MANAGE_REPLY] {
 # -----------------------------------------------------------------------------
 failure_route[MANAGE_FAILURE] {
     if(t_check_status("488") && $dlg_var(SRTPTranscode) == "2") {
-        xlog('L_WARN', "[DEV] - $ci $rm-$cs - in failure route because of 488 and transcode is: $dlg_var(SRTPTranscode) ru is : $ru\n");
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in failure route because of 488 and transcode is: $dlg_var(SRTPTranscode) ru is : $ru\n");
         $avp(failure) = "1";
         append_branch();
         route(RELAY);
@@ -933,7 +933,7 @@ route[REWRITE_CONTACT] {
             break;
     }
     # logging protocol
-    // xlog('L_WARN', "[DEV] - $ci $rm-$cs - protocol: $var(ctProto), int proto: $var(proto) \n");
+    // if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - protocol: $var(ctProto), int proto: $var(proto) \n");
     remove_hf("Contact");
     $var(default_contact) = DEFAULT_CONTACT;
     append_hf("Contact: <sip:$fU@$var(default_contact);$var(contactUriParameters);alias=$si~$sp~$var(proto)>\r\n","Call-ID");


### PR DESCRIPTION
Ensure debug logs are emitted only when shv(debug) is explicitly
enabled. Previously, some debug messages were logged unconditionally,
causing unnecessary noise in production environments.

This change updates several xlog calls to check the value of shv(debug)
before emitting logs.

The default value of the variable is set to 0.
Debug can be enabled with:
```
$ kamcmd pv.shvSet debug int 1
```

Doc: https://kamailio.org/docs/modules/5.8.x/modules/pv.html#pv.rpc.shvSet
