### PR TITLE
feat(kamailio): add kamcmd wrapper

### DIFF
--- a/imageroot/bin/kamcmd
+++ b/imageroot/bin/kamcmd
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Check if stdout is a TTY
+if [[ -t 1 ]] ; then
+    with_tty=1
+fi
+
+podman exec -i ${with_tty:+-t} kamailio kamcmd $@


### PR DESCRIPTION
Introduce a bash script to wrap the `kamcmd` command for use within the
Kamailio container. The script ensures proper handling of TTY when
executing commands via `podman`.

https://github.com/NethServer/dev/issues/7356