### PR TITLE
fix(remove-trunk): correct dialplan match

### DIFF
--- a/imageroot/actions/remove-trunk/20removetrunk
+++ b/imageroot/actions/remove-trunk/20removetrunk
@@ -22,7 +22,7 @@ with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-tAU', os.en
 if proxy_route:
     query = (
             f'DELETE FROM nethvoice_proxy_routes WHERE target=\'{data["rule"]}\' AND setid={proxy_route[0]["setid"]} AND route_type=\'trunk\';\n'
-            f'DELETE FROM dialplan WHERE match_exp=\'{data["rule"]}\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
+            f'DELETE FROM dialplan WHERE match_exp=\'sip:{data["rule"]}.*@.*\' AND repl_exp=\'{proxy_route[0]["setid"]}\' AND attrs=\'{proxy_route[0]["setid"]}\';\n'
             f'DELETE FROM dispatcher WHERE setid={proxy_route[0]["setid"]};\n'
             )
     # Remove the route


### PR DESCRIPTION
Update the SQL delete query in the remove-trunk action to properly match
SIP URIs in the dialplan table. This ensures the match_exp field
includes the "sip:" prefix and the wildcard pattern.

Previously, the query failed to match SIP URIs, leading to incomplete
cleanup of dialplan entries

https://github.com/NethServer/dev/issues/7379
