### PR TITLE
Add backup and restore procedure

### DIFF
--- a/imageroot/actions/create-module/30grants
+++ b/imageroot/actions/create-module/30grants
@@ -18,3 +18,6 @@ routeadm_actions=(
     list-routes
 )
 redis-exec SADD "${AGENT_ID}/roles/routeadm" "${routeadm_actions[@]}"
+
+# Allow the module to call its own actions
+redis-exec SADD "${AGENT_ID}/roles/selfadm" "*"

--- a/imageroot/actions/restore-module/71restore_config
+++ b/imageroot/actions/restore-module/71restore_config
@@ -7,6 +7,7 @@
 
 import json
 import os
+import time
 
 import agent
 
@@ -36,3 +37,9 @@ with open('config_dump.json', 'r') as f:
             data=config
         )
         agent.assert_exp(configure_response['exit_code'] == 0)
+        # By default there is a rate limiting of maximum one reload in five
+        # seconds to be waited before executing a new RPC reload. Executing two
+        # RPC reloads of the same table at the same time can cause Kamailio to
+        # crash.
+        # See: https://www.kamailio.org/docs/modules/stable/modules/permissions.html#permissions.p.reload_delta
+        time.sleep(5)

--- a/imageroot/actions/restore-module/71restore_config
+++ b/imageroot/actions/restore-module/71restore_config
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+
+import agent
+
+response = agent.tasks.run(
+        agent_id=os.environ['AGENT_ID'],
+        action='get-available-interfaces',
+        data= {
+        'excluded_interfaces' :["wg0","lo"],
+        'excluded_families':["inet6"],
+        }
+    )
+agent.assert_exp(response['exit_code'] == 0)
+
+list_ifaces = response['output']['data']
+
+with open('config_dump.json', 'r') as f:
+    config = json.load(f)
+
+    if any(
+            addr['address'] == config['addresses']['address']
+            for iface in list_ifaces
+            for addr in iface['addresses']
+    ):
+        configure_response = agent.tasks.run(
+            agent_id=os.environ['AGENT_ID'],
+            action='configure-module',
+            data=config
+        )
+        agent.assert_exp(configure_response['exit_code'] == 0)

--- a/imageroot/actions/restore-module/71restore_routes
+++ b/imageroot/actions/restore-module/71restore_routes
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+
+import agent
+
+
+with open('routes_dump.json', 'r') as f:
+    routes = json.load(f)
+    for route in routes:
+        response = agent.tasks.run(
+                agent_id=os.environ['AGENT_ID'],
+                action='add-route',
+                data=route
+                )
+        agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/restore-module/71restore_routes
+++ b/imageroot/actions/restore-module/71restore_routes
@@ -7,6 +7,7 @@
 
 import json
 import os
+import time
 
 import agent
 
@@ -20,3 +21,9 @@ with open('routes_dump.json', 'r') as f:
                 data=route
                 )
         agent.assert_exp(response['exit_code'] == 0)
+        # By default there is a rate limiting of maximum one reload in five
+        # seconds to be waited before executing a new RPC reload. Executing two
+        # RPC reloads of the same table at the same time can cause Kamailio to
+        # crash.
+        # See: https://www.kamailio.org/docs/modules/stable/modules/permissions.html#permissions.p.reload_delta
+        time.sleep(5)

--- a/imageroot/actions/restore-module/71restore_trunks
+++ b/imageroot/actions/restore-module/71restore_trunks
@@ -7,6 +7,7 @@
 
 import json
 import os
+import time
 
 import agent
 
@@ -22,3 +23,9 @@ with open('trunks_dump.json', 'r') as f:
                 data=trunk
                 )
         agent.assert_exp(response['exit_code'] == 0)
+        # By default there is a rate limiting of maximum one reload in five
+        # seconds to be waited before executing a new RPC reload. Executing two
+        # RPC reloads of the same table at the same time can cause Kamailio to
+        # crash.
+        # See: https://www.kamailio.org/docs/modules/stable/modules/permissions.html#permissions.p.reload_delta
+        time.sleep(5)

--- a/imageroot/actions/restore-module/71restore_trunks
+++ b/imageroot/actions/restore-module/71restore_trunks
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+
+import agent
+
+# read the file trunks_dump.json with an array of trunks
+with open('trunks_dump.json', 'r') as f:
+    trunks = json.load(f)
+    #invoke the agent to restore trunks
+    for trunk in trunks:
+        # call restore_trunk
+        response = agent.tasks.run(
+                agent_id=os.environ['AGENT_ID'],
+                action='add-trunk',
+                data=trunk
+                )
+        agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/restore-module/99clean
+++ b/imageroot/actions/restore-module/99clean
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2025 Nethesis S..
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+module-cleanup-state

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -9,3 +9,4 @@ set -e
 
 rm -rf routes_dump.json
 rm -rf trunks_dump.json
+rm -rf config_dump.json

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+rm -rf routes_dump.json
+rm -rf trunks_dump.json

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+api-cli run ${AGENT_ID}/list-routes > routes_dump.json
+api-cli run ${AGENT_ID}/list-trunks > trunks_dump.json

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -9,3 +9,4 @@ set -e
 
 api-cli run ${AGENT_ID}/list-routes > routes_dump.json
 api-cli run ${AGENT_ID}/list-trunks > trunks_dump.json
+api-cli run ${AGENT_ID}/get-configuration > config_dump.json

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -1,0 +1,2 @@
+state/routes_dump.json
+state/trunks_dump.json

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -1,2 +1,3 @@
 state/routes_dump.json
 state/trunks_dump.json
+state/config_dump.json

--- a/imageroot/update-module.d/30grants
+++ b/imageroot/update-module.d/30grants
@@ -1,0 +1,1 @@
+../actions/create-module/30grants


### PR DESCRIPTION
This PR adds backup and restore procedures.

The backup is created by dumping the output of the following actions:
- `get-configuration`
- `list-routes`
- `list-trunks`

The restore is performed by reading the dumps and executing the related actions
to restore the configuration.

This PR also extends the `selfadm` role to include all actions of the module,
allowing the module to easily call its own actions.

https://github.com/NethServer/dev/issues/7113
