### PR TITLE
Fix SIP Call Termination Issues with Multiple Record-Route Headers

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -373,6 +373,31 @@ route[WITHINDLG] {
         exit;
     }
     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - after check of loose_route (if you don't see loose_route is OK means it returned false) \n");
+
+    # Handle BYE with stored Contact when loose_route fails
+    if (is_method("BYE")) {
+        if ($dlg_var(target_contact) != $null && $dlg_var(target_contact) != "") {
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - BYE without loose_route - using stored contact: $dlg_var(target_contact) \n");
+
+            # Extract URI from Contact header (which might be in format <sip:user@domain>)
+            $var(target_uri) = $(dlg_var(target_contact){nameaddr.uri});
+            if ($var(target_uri) == $null) {
+                # If parsing as nameaddr fails, use the raw value
+                $var(target_uri) = $dlg_var(target_contact);
+            }
+
+            # Set request URI and destination URI to the stored contact
+            $ru = $var(target_uri);
+            $du = $var(target_uri);
+
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Set ru/du to stored contact: $ru \n");
+
+            route(NATMANAGE);
+            route(RELAY);
+            exit;
+        }
+    }
+
     if(is_method("PRACK")) {
         if($shv(fakeprack) == 1) {
             if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - PRACK received and shv fakeprack is set, sending 200 OK and not relaying \n");
@@ -724,6 +749,13 @@ onreply_route[MANAGE_REPLY] {
         $dlg_var(direction) = $avp(direction);
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
         
+        # Store Contact URI for later use in dialog, especially for BYE requests
+        if (is_method("INVITE") && has_body("application/sdp") && $rs=~"^2[0-9][0-9]") {
+            # Store the Contact header from 200 OK responses to INVITE
+            $dlg_var(target_contact) = $ct;
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");
+        }
+
         route(NATMANAGE);
     }
 } # end of onreply_route[MANAGE_REPLY]

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -375,37 +375,31 @@ route[WITHINDLG] {
         }
         # handling advanced NAT if this packet goes to private IP address and direction is OUT
         // if($ru{uri.host})
+        # Handle BYE with stored Contact when loose_route fails
+        if (is_method("BYE")) {
+            if ($dlg_var(target_contact) != $null && $dlg_var(target_contact) != "") {
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - BYE without loose_route - using stored contact: $dlg_var(target_contact) \n");
+
+                # Extract URI from Contact header (which might be in format <sip:user@domain>)
+                $var(target_uri) = $(dlg_var(target_contact){nameaddr.uri});
+                if ($var(target_uri) == $null) {
+                    # If parsing as nameaddr fails, use the raw value
+                    $var(target_uri) = $dlg_var(target_contact);
+                }
+
+                # Set request URI and destination URI to the stored contact
+                $ru = $var(target_uri);
+                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Set ru to stored contact: $ru \n");
+            }
+        }
+  
         if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - doing RELAY with destination : ru: $ru du: $du , host : $(ru{uri.host})\n");
         route(RELAY);
         exit;
     }
     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - after check of loose_route (if you don't see loose_route is OK means it returned false) \n");
 
-    # Handle BYE with stored Contact when loose_route fails
-    if (is_method("BYE")) {
-        if ($dlg_var(target_contact) != $null && $dlg_var(target_contact) != "") {
-            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - BYE without loose_route - using stored contact: $dlg_var(target_contact) \n");
-
-            # Extract URI from Contact header (which might be in format <sip:user@domain>)
-            $var(target_uri) = $(dlg_var(target_contact){nameaddr.uri});
-            if ($var(target_uri) == $null) {
-                # If parsing as nameaddr fails, use the raw value
-                $var(target_uri) = $dlg_var(target_contact);
-            }
-
-            # Set request URI and destination URI to the stored contact
-            $ru = $var(target_uri);
-            $du = $var(target_uri);
-
-            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Set ru/du to stored contact: $ru \n");
-
-            route(NATMANAGE);
-            route(RELAY);
-            exit;
-        }
-    }
-
-    if(is_method("PRACK")) {
+   if(is_method("PRACK")) {
         if($shv(fakeprack) == 1) {
             if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - PRACK received and shv fakeprack is set, sending 200 OK and not relaying \n");
             sl_send_reply("200","OK");

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -239,6 +239,13 @@ request_route {
     }
     if (is_method("INVITE|SUBSCRIBE|PUBLISH|NOTIFY|UPDATE")) {
         record_route();
+
+        # Store Contact URI for later use in dialog, especially for BYE requests
+        if (is_method("INVITE") && has_body("application/sdp")) {
+            # Store the Contact header from 200 OK responses to INVITE
+            $dlg_var(target_contact) = $ct;
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");
+        }
     }
     # account only INVITEs
     // if (is_method("INVITE")) {
@@ -748,13 +755,6 @@ onreply_route[MANAGE_REPLY] {
         }
         $dlg_var(direction) = $avp(direction);
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
-        
-        # Store Contact URI for later use in dialog, especially for BYE requests
-        if (is_method("INVITE") && has_body("application/sdp") && $rs=~"^2[0-9][0-9]") {
-            # Store the Contact header from 200 OK responses to INVITE
-            $dlg_var(target_contact) = $ct;
-            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");
-        }
 
         route(NATMANAGE);
     }

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -241,7 +241,7 @@ request_route {
         record_route();
 
         # Store Contact URI for later use in dialog, especially for BYE requests
-        if (is_method("INVITE") && has_body("application/sdp")) {
+        if (is_method("INVITE") && has_body("application/sdp") && $dlg_var(direction)== "in") {
             # Store the Contact header from 200 OK responses to INVITE
             $dlg_var(target_contact) = $ct;
             if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");


### PR DESCRIPTION
This PR addresses an issue with SIP call termination when interacting with providers that use multiple Record-Route headers (such as Voipvoice).

Problem:
When attempting to terminate calls from providers using multiple Record-Route headers, BYE requests receive "404 Not Here" responses. Analysis of SIP traces revealed:

- The INVITE message contains multiple Record-Route headers (four in total)
- The original Contact header in the INVITE response isn't being used for BYE requests
- BYE messages are incorrectly sent to the provider's IP address instead of the Contact URI

This violates RFC 3261, which requires using the Contact URI from the initial dialog establishment for terminating requests.

Solution:
This PR store the INVITE Contact URI the use it if the BYE loose_route() check fails.

https://evoseed.atlassian.net/servicedesk/customer/portal/5/EA-61

https://github.com/NethServer/dev/issues/7485