### PR TITLE
feature(kamailio): don't offer SRTP on RTP negotiated calls

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -556,14 +556,17 @@ route[NATMANAGE] {
     }
     # -------------------------------------------------------------------------------------------------------------------------
     $var(rtpAppend) = "";
-    $var(isTrunk) = "0";
     $var(isTrunk) = $hdr(isTrunk);
+    if ($dlg_var(isTrunk) == $null) {
+        $dlg_var(isTrunk) = "0";
+    }
     if(is_method("INVITE") && $var(isTrunk) == "1"){
+        $dlg_var(isTrunk) = "1";
         // removing the isTrunk header
         remove_hf("isTrunk");
     }
 
-    if(is_method("INVITE") && has_body("application/sdp") && $var(isTrunk) == "0"){
+    if(is_method("INVITE") && has_body("application/sdp") && $dlg_var(isTrunk) == "0"){
         if( (is_method("INVITE") && $avp(direction) == 'in' || $dlg_var(direction) == 'in')  && is_request() && (sdp_with_transport("RTP/SAVPF") || sdp_with_transport("RTP/SAVP"))) {
             if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal !! doing SRTP to RTP if SRTP is present \n");
             $dlg_var(trascoding) = 't';

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -558,21 +558,19 @@ route[NATMANAGE] {
     $var(rtpAppend) = "";
     $var(isTrunk) = "0";
     $var(isTrunk) = $hdr(isTrunk);
-    if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - transcoding: $dlg_var(trascoding) \n");
     if ($dlg_var(no_encryption) == $null) {
         $dlg_var(no_encryption) = "0";
-        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent no_encryption 0 \n");
     }
     if(is_method("INVITE") && $var(isTrunk) == "1"){
         $dlg_var(no_encryption) = "1";
-        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent no_encryption 1 \n");
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - isTrunk header present, setting persistent no_encryption to 1 \n");
         // removing the isTrunk header
         remove_hf("isTrunk");
     }
 
     if(is_method("INVITE") && has_body("application/sdp") && $dlg_var(no_encryption) == "0"){
         if( (is_method("INVITE") && $avp(direction) == 'in' || $dlg_var(direction) == 'in')  && is_request() && sdp_with_transport("RTP/AVP")) {
-            if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal, unencrypted \n");
+            if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal, unencrypted, setting persistent no_encryption \n");
             // setting persistent no_encryption to 1 to avoid to offer encryption on re-INVITE
             $dlg_var(no_encryption) = "1";
         }

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -556,17 +556,22 @@ route[NATMANAGE] {
     }
     # -------------------------------------------------------------------------------------------------------------------------
     $var(rtpAppend) = "";
+    $var(isTrunk) = "0";
     $var(isTrunk) = $hdr(isTrunk);
+    if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - transcoding: $dlg_var(trascoding) \n");
     if ($dlg_var(isTrunk) == $null) {
         $dlg_var(isTrunk) = "0";
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 0 \n");
     }
     if(is_method("INVITE") && $var(isTrunk) == "1"){
         $dlg_var(isTrunk) = "1";
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 1 \n");
         // removing the isTrunk header
         remove_hf("isTrunk");
     }
 
     if(is_method("INVITE") && has_body("application/sdp") && $dlg_var(isTrunk) == "0"){
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 0 \n");
         if( (is_method("INVITE") && $avp(direction) == 'in' || $dlg_var(direction) == 'in')  && is_request() && (sdp_with_transport("RTP/SAVPF") || sdp_with_transport("RTP/SAVP"))) {
             if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal !! doing SRTP to RTP if SRTP is present \n");
             $dlg_var(trascoding) = 't';

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -559,19 +559,24 @@ route[NATMANAGE] {
     $var(isTrunk) = "0";
     $var(isTrunk) = $hdr(isTrunk);
     if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - transcoding: $dlg_var(trascoding) \n");
-    if ($dlg_var(isTrunk) == $null) {
-        $dlg_var(isTrunk) = "0";
-        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 0 \n");
+    if ($dlg_var(no_encryption) == $null) {
+        $dlg_var(no_encryption) = "0";
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent no_encryption 0 \n");
     }
     if(is_method("INVITE") && $var(isTrunk) == "1"){
-        $dlg_var(isTrunk) = "1";
-        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 1 \n");
+        $dlg_var(no_encryption) = "1";
+        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent no_encryption 1 \n");
         // removing the isTrunk header
         remove_hf("isTrunk");
     }
 
-    if(is_method("INVITE") && has_body("application/sdp") && $dlg_var(isTrunk) == "0"){
-        if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - persistent isTrunk 0 \n");
+    if(is_method("INVITE") && has_body("application/sdp") && $dlg_var(no_encryption) == "0"){
+        if( (is_method("INVITE") && $avp(direction) == 'in' || $dlg_var(direction) == 'in')  && is_request() && sdp_with_transport("RTP/AVP")) {
+            if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal, unencrypted \n");
+            // setting persistent no_encryption to 1 to avoid to offer encryption on re-INVITE
+            $dlg_var(no_encryption) = "1";
+        }
+
         if( (is_method("INVITE") && $avp(direction) == 'in' || $dlg_var(direction) == 'in')  && is_request() && (sdp_with_transport("RTP/SAVPF") || sdp_with_transport("RTP/SAVP"))) {
             if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - from external to internal !! doing SRTP to RTP if SRTP is present \n");
             $dlg_var(trascoding) = 't';


### PR DESCRIPTION
This PR solves https://github.com/NethServer/dev/issues/7546:

- when a call is originated from internal and has the isTrunk header, the isTrunk state is saved for the session and re-INVITES that came from internal doesn't have the encryption offered to the external device
- when a call is originated from external and doesn't have encryption, the "no encryption" state is saved for that call and encryption isn't offered for re-INVITE of that call