### PR TITLE
fix(kamailio): Store contact to be used for BYE only if there are >1 Record-Route

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -242,7 +242,7 @@ request_route {
         record_route();
 
         # Store Contact URI for later use in dialog, especially for BYE requests
-        if (is_method("INVITE") && has_body("application/sdp") && $dlg_var(direction)== "in") {
+        if (is_method("INVITE") && has_body("application/sdp") && $dlg_var(direction)== "in" && $rr_count > 1) {
             # Store the Contact header from 200 OK responses to INVITE
             $dlg_var(target_contact) = $ct;
             if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");


### PR DESCRIPTION
This [fix](https://github.com/nethesis/ns8-nethvoice-proxy/pull/63)  for changing BYE destination to the contact, break some phones (Snom, Yealink), because in the contact uses the privat ip instead of public if they are remote and don't use STUN. Since the original problem with BYE is triggered only if there are multiple Record-Routes in the first INVITE, with this fix the first INVITE contact is stored only if there are more than one Record-Route header in the packet 

https://github.com/NethServer/dev/issues/7485