### PR TITLE
feat(kamailio): Enhance request routing and keepalive handling

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -358,7 +358,7 @@ route[KEEPALIVE] {
     # if there are preloaded Route headers (e.g. to us, then provider), do not intervene:
     if ($hdr(Route) != $null) return;
 
-    # 1) Healthcheck locale
+    # 1) Healthcheck local
     if ($si == "127.0.0.1" && uri==myself) {
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in KEEPALIVE route and si is 127.0.0.1 and uri is myself \n");
         sl_send_reply("200","Keepalive"); exit;


### PR DESCRIPTION
- Added handling for NOTIFY requests to respond with 200 OK for internal requests and 404 for external ones.
- Improved OPTIONS method processing within the request route.
- Updated KEEPALIVE route to handle various scenarios, including local health checks and internal network requests.
- Enhanced logging for debugging purposes throughout the request handling process.

https://github.com/NethServer/dev/issues/7624