### PR TITLE
fix(kamailio): increase timers for NOTIFY/SUBSCRIBE to fix BLF timeouts

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -835,6 +835,7 @@ onreply_route[MANAGE_REPLY] {
         $dlg_var(direction) = $avp(direction);
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
 
+        route(SET_TIMERS);
         route(NATMANAGE);
     }
 } # end of onreply_route[MANAGE_REPLY]
@@ -1002,6 +1003,7 @@ route[ADD_TO_IPBAN] {
 # - fr_timeout - new final response timeout (in milliseconds) for non-INVITE transaction, or INVITEs which haven't received yet a provisional response. See also fr_timer.
 # -----------------------------------------------------------------------------
 route[SET_TIMERS] {
+    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in SET_TIMERS route, and method is: $rm \n");
     if (is_method("INVITE")) {
         t_set_fr(FR_INV_TIMEOUT, FR_TIMEOUT_100);
         return;
@@ -1015,12 +1017,16 @@ route[SET_TIMERS] {
     # NOTIFY (BLF): timeout aumentato per gestire telefoni Snom lenti
     if (is_method("NOTIFY")) {
         t_set_fr(0, FR_TIMEOUT_NOTIFY);
+        $var(log_fr_timeout) = "FR_TIMEOUT_NOTIFY";
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - setting fr timeout for NOTIFY to: $var(log_fr_timeout) \n");
         return;
     }
 
     # SUBSCRIBE: stesso trattamento delle NOTIFY per coerenza dialog BLF
     if (is_method("SUBSCRIBE")) {
         t_set_fr(0, FR_TIMEOUT_NOTIFY);
+        $var(log_fr_timeout) = "FR_TIMEOUT_NOTIFY";
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - setting fr timeout for SUBSCRIBE to: $var(log_fr_timeout) \n");
         return;
     }
 

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -315,6 +315,7 @@ request_route {
                 route(REWRITE_CONTACT);
                 // add_contact_alias();
             }
+            route(SET_TIMERS);
             route(RELAY);
             exit;
         } else {
@@ -1001,8 +1002,30 @@ route[ADD_TO_IPBAN] {
 # - fr_timeout - new final response timeout (in milliseconds) for non-INVITE transaction, or INVITEs which haven't received yet a provisional response. See also fr_timer.
 # -----------------------------------------------------------------------------
 route[SET_TIMERS] {
-    # set the fr_inv_timeout
-    t_set_fr(FR_INV_TIMEOUT, FR_TIMEOUT_100);
+    if (is_method("INVITE")) {
+        t_set_fr(FR_INV_TIMEOUT, FR_TIMEOUT_100);
+        return;
+    }
+
+    if (is_method("BYE")) {
+        t_set_fr(0, FR_TIMEOUT_BYE);
+        return;
+    }
+
+    # NOTIFY (BLF): timeout aumentato per gestire telefoni Snom lenti
+    if (is_method("NOTIFY")) {
+        t_set_fr(0, FR_TIMEOUT_NOTIFY);
+        return;
+    }
+
+    # SUBSCRIBE: stesso trattamento delle NOTIFY per coerenza dialog BLF
+    if (is_method("SUBSCRIBE")) {
+        t_set_fr(0, FR_TIMEOUT_NOTIFY);
+        return;
+    }
+
+    # Default per altri metodi non-INVITE
+    t_set_fr(0, FR_TIMEOUT_100);
 } # end of route[SET_TIMERS]
 
 # -----------------------------------------------------------------------------

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -159,7 +159,7 @@ modparam("keepalive", "ping_from", PING_FROM)
 modparam("keepalive", "delete_counter", 5)
 modparam("http_async_client", "workers", 2)
 modparam("uac", "restore_dlg", 1)
-modparam("pv", "shvset", "debug=i:1")
+modparam("pv", "shvset", "debug=i:0")
 modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")
@@ -1013,23 +1013,19 @@ route[SET_TIMERS] {
         return;
     }
 
-    # NOTIFY (BLF): timeout aumentato per gestire telefoni Snom lenti
+    # NOTIFY (BLF): increased timeout to handle slow Snom phones
     if (is_method("NOTIFY")) {
         t_set_fr(0, FR_TIMEOUT_NOTIFY);
-        $var(log_fr_timeout) = "FR_TIMEOUT_NOTIFY";
-        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - setting fr timeout for NOTIFY to: $var(log_fr_timeout) \n");
         return;
     }
 
-    # SUBSCRIBE: stesso trattamento delle NOTIFY per coerenza dialog BLF
+    # SUBSCRIBE: same treatment as NOTIFY for BLF dialog consistency
     if (is_method("SUBSCRIBE")) {
         t_set_fr(0, FR_TIMEOUT_NOTIFY);
-        $var(log_fr_timeout) = "FR_TIMEOUT_NOTIFY";
-        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - setting fr timeout for SUBSCRIBE to: $var(log_fr_timeout) \n");
         return;
     }
 
-    # Default per altri metodi non-INVITE
+    # Default for other non-INVITE methods
     t_set_fr(0, FR_TIMEOUT_100);
 } # end of route[SET_TIMERS]
 
@@ -1107,7 +1103,12 @@ route[SET_SOCKET] {
     if(is_request()) {
         # print $rd is an ip and is in LOCALNETWORKS then print it
         $var(destination_ip)= $null; # reinitialize the variable
-        $var(destination_ip) = $(ru{uri.host}); # fetch the destination ip from ru
+        # if $du is present, the destination ip is the one in $du
+        if ($du != $null && $du != 0 && $du != "") {
+            $var(destination_ip) = $(du{uri.host});
+        } else {
+            $var(destination_ip) = $(ru{uri.host}); # fetch the destination ip from ru
+        }
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip: $var(destination_ip) \n");
         if ($var(destination_ip) != $null && $var(destination_ip) != 0 && $var(destination_ip) != "") {
             if ($avp(direction) == 'in' && $dlg_var(direction) == 'in') {

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -159,7 +159,7 @@ modparam("keepalive", "ping_from", PING_FROM)
 modparam("keepalive", "delete_counter", 5)
 modparam("http_async_client", "workers", 2)
 modparam("uac", "restore_dlg", 1)
-modparam("pv", "shvset", "debug=i:0")
+modparam("pv", "shvset", "debug=i:1")
 modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")
@@ -418,8 +418,6 @@ route[WITHINDLG] {
         route(DLGURI);
         if ( is_method("ACK") ) {
             # ACK is forwarded statelessly
-            # Ensure correct socket is used for ACKs across all relevant network types
-            route(SET_SOCKET);
             route(NATMANAGE);
         } else if ( is_method("NOTIFY") ) {
             # Add Record-Route for in-dialog NOTIFY as per RFC 6665.
@@ -446,6 +444,7 @@ route[WITHINDLG] {
         }
 
         if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - doing RELAY with destination : ru: $ru du: $du , host : $(ru{uri.host})\n");
+        route(SET_TIMERS);
         route(RELAY);
         exit;
     }
@@ -823,7 +822,7 @@ onreply_route[MANAGE_REPLY] {
     if ($rs=~"[12][0-9][0-9]|488") {
         if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in reply route (MANAGE_REPLY) and Response code is: $rs \n");
         # handling avp and dlg_var direction
-        # printing $si 
+        # printing $si
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - si: $si, rs: $rs \n");
         # $si is correctly set, to 10.5.4.1
         # setting direction in opposite (as it's a reply)
@@ -1105,22 +1104,12 @@ route[HANDLE_ALIAS] {
 # -----------------------------------------------------------------------------
 route[SET_SOCKET] {
     if( $shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in SET_SOCKET route \n");
-    if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: ENTER \n");
     if(is_request()) {
-        if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: is_request=TRUE \n");
         # print $rd is an ip and is in LOCALNETWORKS then print it
         $var(destination_ip)= $null; # reinitialize the variable
-        # if $du is present, the destination ip is the one in $du
-        if ($du != $null && $du != 0 && $du != "") {
-            $var(destination_ip) = $(du{uri.host});
-        } else {
-            $var(destination_ip) = $(ru{uri.host}); # fetch the destination ip from ru
-        }
-        if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: destination_ip=$var(destination_ip) ru=$ru \n");
+        $var(destination_ip) = $(ru{uri.host}); # fetch the destination ip from ru
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip: $var(destination_ip) \n");
-        if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: before validity check \n");
         if ($var(destination_ip) != $null && $var(destination_ip) != 0 && $var(destination_ip) != "") {
-            if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: destination_ip is VALID \n");
             if ($avp(direction) == 'in' && $dlg_var(direction) == 'in') {
                 if (($du == $null) && ($ru =~ "^sips:") && !($ru =~ ";transport=")) {
                     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - ru: $ru - du: $du - Rewriting ru and du for EA-51 \n");
@@ -1170,28 +1159,17 @@ route[SET_SOCKET] {
                 if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
             }
             # Handle traffic to INTERNAL_NETWORK (service network where Asterisk lives)
-            if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: about to check INTERNAL_NETWORK for $var(destination_ip) \n");
-            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - checking if $var(destination_ip) is in INTERNAL_NETWORK \n");
             if (is_in_subnet($var(destination_ip), INTERNAL_NETWORK)) {
-                if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: MATCH! $var(destination_ip) IS in INTERNAL_NETWORK \n");
                 if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip is in INTERNAL_NETWORK, forcing socket to SERVICE_IP \n");
                 # Force using the service network interface
                 $fs = SERVICE_IP + ":5060";
-                if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: forced $fs \n");
                 # replace external in rtpengine_conf with internal
                 $var(rtpengine_conf) = $(var(rtpengine_conf){s.replace,external,internal});
                 if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - forced socket: $fs, rtpengine_conf: $var(rtpengine_conf) \n");
-            } else {
-                if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: NO MATCH! $var(destination_ip) NOT in INTERNAL_NETWORK \n");
-                if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - destination ip $var(destination_ip) is NOT in INTERNAL_NETWORK \n");
             }
-        } else {
-            if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: destination_ip INVALID (null/0/empty) \n");
         }
     } else {
-        if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: is_request=FALSE, checking is_reply \n");
         if(is_reply()){
-            if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: is_reply=TRUE \n");
             $var(destination_ip)= $null; # reinitialize the variable
             # logging $dlg_var(source_ip)
             if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Original source ip: $dlg_var(source_ip) \n");
@@ -1237,4 +1215,3 @@ route[SET_SOCKET] {
         }
     }
 } # end of route[SET_SOCKET]
-# TT157 TEST MARKER

--- a/modules/kamailio/config/template.kamailio-local.cfg
+++ b/modules/kamailio/config/template.kamailio-local.cfg
@@ -13,6 +13,9 @@
 # Timer on BYE reqests. Prevent unnecessary BYE failovers.
 #!define FR_TIMEOUT_BYE 3000
 
+# Timer for BLF NOTIFY/SUBSCRIBE - increased to handle slow Snom phones
+#!define FR_TIMEOUT_NOTIFY 5000
+
 # Timer which hits if no final reply for a request or ACK for a negative INVITE reply arrives.
 # External. Can be considered constant.
 #!define FR_TIMEOUT 30000


### PR DESCRIPTION
## Summary

Fixes timeout issues affecting BLF (Busy Lamp Field) NOTIFY/SUBSCRIBE traffic with Snom phones (TT164).

## Changes

- **New timer `FR_TIMEOUT_NOTIFY` (5000 ms)** in `template.kamailio-local.cfg` — dedicated final-response timer for NOTIFY/SUBSCRIBE methods, tuned for slow Snom phones that would otherwise hit the default timeout.
- **Expanded `SET_TIMERS` route** in `kamailio.cfg` — applies the dedicated timer to NOTIFY/SUBSCRIBE requests and their replies, leaving other methods on default timers.
- **`SET_TIMERS` invoked in `WITHINDLG`** as well — SUBSCRIBE refreshes are in-dialog requests, so the timer must be applied there too.
- **Kamailio version bump** from 5.8.7 → 5.8.8 in the Dockerfile (already merged via main).

## Test plan

- [ ] Verify BLF subscriptions from Snom phones no longer time out under load
- [ ] Verify standard SIP traffic (INVITE/REGISTER/BYE) still uses default timers
- [ ] Smoke test on GNS3 lab