### PR TITLE
build(kamailio): update base image to Ubuntu 24.04

### DIFF
--- a/modules/kamailio/Dockerfile
+++ b/modules/kamailio/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Giovanni Tommasini <giovanni.tommasini@evoseed.io>"
 
@@ -9,16 +9,16 @@ ENV DEBIAN_FRONTEND="noninteractive"
 ENV KAMAILIO_VERSION="5.8.8"
 
 RUN apt-get update && apt-get install --no-install-recommends --assume-yes gnupg wget && rm -rf /var/lib/apt/lists/*
-RUN echo "deb http://deb.kamailio.org/kamailio58 focal main" > /etc/apt/sources.list.d/kamailio.list
+RUN echo "deb http://deb.kamailio.org/kamailio58 noble main" > /etc/apt/sources.list.d/kamailio.list
 RUN wget -O- http://deb.kamailio.org/kamailiodebkey.gpg | apt-key add -
 RUN apt-get update && apt-get install --no-install-recommends --assume-yes \
-    kamailio=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-extra-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-json-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-postgres-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-redis-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-tls-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
-    kamailio-utils-modules=${KAMAILIO_VERSION}+ubuntu20.04 \
+    kamailio=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-extra-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-json-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-postgres-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-redis-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-tls-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
+    kamailio-utils-modules=${KAMAILIO_VERSION}+ubuntu24.04 \
     gettext-base && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Switch Dockerfile base from Ubuntu 20.04 to 24.04 to ensure long-term
security updates and better compatibility with Kamailio 5.8.6. Update
APT repository from focal to noble and adjust package names to match
the new distribution suffixes.
