### PR TITLE
build(rtpengine): migrate to Ubuntu 24.04

### DIFF
--- a/modules/rtpengine/Dockerfile
+++ b/modules/rtpengine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:24.04 as builder
 
 LABEL maintainer="Giovanni Tommasini <giovanni.tommasini@evoseed.io>"
 
@@ -7,8 +7,8 @@ ENV TZ="Europe/Rome"
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get -qq update \
-    && apt-get -qq --no-install-recommends install \
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
     debhelper \
     ca-certificates \
     libxtables-dev \
@@ -58,9 +58,7 @@ RUN apt-get -qq update \
     libcurl4-openssl-dev \
     jq \
     mtr-tiny \
-    netcat \
-    net-tools \
-    traceroute
+    net-tools
 
 RUN rm -Rf /src \
     && mkdir /src && cd /src \
@@ -80,7 +78,7 @@ RUN cd /src/rtpengine/ \
     && dpkg-checkbuilddeps \
     && DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage --no-sign
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV TZ="Europe/Rome"
 
@@ -91,10 +89,10 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
     ca-certificates \
     gettext-base \
     iptables \
-    libavcodec58 \
-    libavfilter7 \
-    libavformat58 \
-    libavutil56 \
+    libavcodec60 \
+    libavfilter9 \
+    libavformat60 \
+    libavutil58 \
     libbencode-perl \
     libconfig-tiny-perl \
     libcrypt-rijndael-perl \
@@ -102,7 +100,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
     libevent-2.1-7 \
     libevent-pthreads-2.1-7 \
     libglib2.0-0 \
-    libhiredis0.14 \
+    libhiredis1.1.0 \
     libio-socket-inet6-perl \
     libip4tc2 \
     libip6tc2 \
@@ -110,11 +108,12 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
     libmosquitto1 \
     libmysqlclient21 \
     libopus0 \
-    libpcap0.8 \
+    libpcap0.8t64 \
+    libpcre3 \
     libsocket6-perl \
-    libspandsp2 \
-    libswresample3 \
-    libwebsockets16 \
+    libspandsp2t64 \
+    libswresample4 \
+    libwebsockets19t64 \
     libxmlrpc-core-c3 \
     netcat-openbsd \
     nfs-common \


### PR DESCRIPTION
Migrate the rtpengine container from Ubuntu 22.04 to 24.04. This brings
us up to date with a supported Ubuntu LTS release.

Update all runtime library dependencies to their Ubuntu 24.04
equivalents:
- libavcodec58 -> libavcodec60
- libavfilter7 -> libavfilter9
- libavformat58 -> libavformat60
- libavutil56 -> libavutil58
- libhiredis0.14 -> libhiredis1.1.0
- libpcap0.8 -> libpcap0.8t64 (time64 transition)
- libspandsp2 -> libspandsp2t64
- libswresample3 -> libswresample4
- libwebsockets16 -> libwebsockets19t64

Add the previously missing libpcre3 dependency, which is still available
in Ubuntu 24.04 for compatibility. Remove obsolete packages that are no
longer needed (netcat, traceroute).

The resulting image is fully functional with rtpengine 11.2.2.0.
