### PR TITLE
feat: Dynamic port slot binding for multi-trunk support (Vianova)

### DIFF
--- a/imageroot/actions/add-slot-domain/20writeslotdomain
+++ b/imageroot/actions/add-slot-domain/20writeslotdomain
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+import subprocess
+import sys
+
+data = json.load(sys.stdin)
+
+query = (
+    "INSERT INTO slot_domains (key_name, key_value, key_type, value_type, expires) "
+    f"VALUES ('{data['domain']}', '1', 0, 0, 0) "
+    "ON CONFLICT (key_name) DO UPDATE "
+    "SET key_value = EXCLUDED.key_value, "
+    "key_type = EXCLUDED.key_type, "
+    "value_type = EXCLUDED.value_type, "
+    "expires = EXCLUDED.expires;\n"
+)
+
+with subprocess.Popen(
+    ['podman', 'exec', '-i', 'postgres', 'psql', '-qU', os.environ["POSTGRES_USER"], os.environ["POSTGRES_DB"]],
+    stdin=subprocess.PIPE,
+    text=True,
+) as psql:
+    print(query, file=psql.stdin)

--- a/imageroot/actions/add-slot-domain/30reload_modules
+++ b/imageroot/actions/add-slot-domain/30reload_modules
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+cat << EOF | podman exec -i kamailio kamcmd > /dev/null
+htable.reload slotdomains
+EOF

--- a/imageroot/actions/add-slot-domain/validate-input.json
+++ b/imageroot/actions/add-slot-domain/validate-input.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "add-slot-domain input",
+  "$id": "http://schema.nethserver.org/nethvoice-proxy/add-slot-domain-input.json",
+  "description": "Add or update a slot-enabled SIP domain",
+  "examples": [
+    {
+      "domain": "voip.vianova.it"
+    }
+  ],
+  "type": "object",
+  "required": ["domain"],
+  "additionalProperties": false,
+  "properties": {
+    "domain": {
+      "type": "string",
+      "title": "SIP domain",
+      "format": "idn-hostname",
+      "minLength": 1,
+      "examples": ["voip.vianova.it"]
+    }
+  }
+}

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -6,45 +6,19 @@
 #
 
 import json
-import sys
 import agent
-import subprocess
 import os
-
-BASE_PUBLIC_PORTS = [
-    "5060-5061/tcp",
-    "5060/udp",
-    "10000-20000/udp",
-]
-
-NAT_PUBLIC_PORTS = [
-    "6060-6061/tcp",
-    "6060/udp",
-]
+import firewall
+import sys
 
 data = json.load(sys.stdin)
 
 local_networks = set()
 
-# Function to create rich rules for port forwarding
-def create_port_forward_rules(local_networks_list):
-    """Create rich rules for each local network"""
-    rules = []
-    for network in local_networks_list:
-        if network:  # Skip empty networks
-            # Port forward 5060 UDP to 6060
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=udp to-port=6060')
-            # Port forward 5060 TCP to 6060
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=tcp to-port=6060')
-            # Port forward 5061 TCP to 6061
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5061 protocol=tcp to-port=6061')
-    return rules
-
 def set_public_firewall_ports(behind_nat):
-    ports = BASE_PUBLIC_PORTS + NAT_PUBLIC_PORTS if behind_nat else BASE_PUBLIC_PORTS
     agent.assert_exp(agent.add_public_service(
         os.environ["MODULE_ID"],
-        ports,
+        firewall.get_public_service_ports(behind_nat),
         replace_ports=True,
     ))
 
@@ -61,7 +35,7 @@ if "addresses" in data:
         prev_private_ip = os.environ.get("PRIVATE_IP")
         if prev_localnetworks and prev_private_ip:
             prev_networks = [n for n in prev_localnetworks.split(",") if n]
-            previous_rules = create_port_forward_rules(prev_networks)
+            previous_rules = firewall.create_port_forward_rules(prev_networks)
             if previous_rules:
                 result = agent.remove_rich_rules(previous_rules)
                 if not result:
@@ -90,7 +64,7 @@ if "addresses" in data:
         prev_private_ip = os.environ.get("PRIVATE_IP")
         if prev_localnetworks and prev_private_ip:
             prev_networks = [n for n in prev_localnetworks.split(",") if n]
-            previous_rules = create_port_forward_rules(prev_networks)
+            previous_rules = firewall.create_port_forward_rules(prev_networks)
             if previous_rules:
                 agent.remove_rich_rules(previous_rules)
 
@@ -104,7 +78,7 @@ if "addresses" in data:
 
         # Create and apply new port forwarding rules for each local network
         if local_networks:
-            new_rules = create_port_forward_rules(list(local_networks))
+            new_rules = firewall.create_port_forward_rules(list(local_networks))
             if new_rules:
                 result = agent.add_rich_rules(new_rules)
                 if not result:

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -36,7 +36,7 @@ agent.set_env('PRIVATE_IP', '')
 agent.set_env('DEFAULT_CONTACT', '127.0.0.1:5060')
 agent.set_env('KML_DEFAULT_FQDN', str(random.randint(0, 32767)).zfill(5) + '.ns8.invalid')
 agent.set_env('BEHIND_NAT', "false")
-agent.set_env('TRUNK_SLOTS', '0')
+agent.set_env('TRUNK_SLOTS', '10')
 agent.set_env('TRUNK_PORT_START', '5071')
 
 rdb = agent.redis_connect(privileged=False)

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -36,6 +36,8 @@ agent.set_env('PRIVATE_IP', '')
 agent.set_env('DEFAULT_CONTACT', '127.0.0.1:5060')
 agent.set_env('KML_DEFAULT_FQDN', str(random.randint(0, 32767)).zfill(5) + '.ns8.invalid')
 agent.set_env('BEHIND_NAT', "false")
+agent.set_env('TRUNK_SLOTS', '0')
+agent.set_env('TRUNK_PORT_START', '5071')
 
 rdb = agent.redis_connect(privileged=False)
 # Get the VPN IP address from the node

--- a/imageroot/actions/create-module/20firewall
+++ b/imageroot/actions/create-module/20firewall
@@ -7,10 +7,11 @@
 
 import os
 import agent
+import firewall
 
-# Open SIP 5060 (TCP/UDP), SIPS 5061 (TCP only) and RTP range (10000-20000).
-# NAT-only ports 6060/6061 are managed during configure-module.
-agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], [
-    "5060-5061/tcp",
-    "5060/udp",
-    "10000-20000/udp"]))
+# Open legacy SIP/RTP ports plus any slot range defined through TRUNK_* envs.
+# NAT-only ports 6060/6061 are still managed during configure-module.
+agent.assert_exp(agent.add_public_service(
+    os.environ['MODULE_ID'],
+    firewall.get_public_service_ports(behind_nat=False),
+))

--- a/imageroot/actions/destroy-module/20firewall
+++ b/imageroot/actions/destroy-module/20firewall
@@ -8,20 +8,7 @@
 import os
 import sys
 import agent
-
-# Function to create rich rules for port forwarding (same as configure-module)
-def create_port_forward_rules(local_networks_list):
-    """Create rich rules for each local network"""
-    rules = []
-    for network in local_networks_list:
-        if network:  # Skip empty networks
-            # Port forward 5060 UDP to 6060
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=udp to-port=6060')
-            # Port forward 5060 TCP to 6060
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=tcp to-port=6060')
-            # Port forward 5061 TCP to 6061
-            rules.append(f'rule family=ipv4 source address={network} forward-port port=5061 protocol=tcp to-port=6061')
-    return rules
+import firewall
 
 # Clean up any existing port forwarding rich rules.
 # LOCALNETWORKS is the marker that NAT-specific rich rules were created.
@@ -30,7 +17,7 @@ prev_localnetworks = os.environ.get("LOCALNETWORKS")
 # Remove rich rules whenever the local networks were configured.
 if prev_localnetworks:
     prev_networks = [n for n in prev_localnetworks.split(",") if n]
-    previous_rules = create_port_forward_rules(prev_networks)
+    previous_rules = firewall.create_port_forward_rules(prev_networks)
     if previous_rules:
         result = agent.remove_rich_rules(previous_rules)
         if not result:

--- a/imageroot/pypkg/firewall.py
+++ b/imageroot/pypkg/firewall.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+
+
+BASE_PUBLIC_PORTS = [
+    "5060-5061/tcp",
+    "5060/udp",
+    "10000-20000/udp",
+]
+
+NAT_PUBLIC_PORTS = [
+    "6060-6061/tcp",
+    "6060/udp",
+]
+
+DEFAULT_TRUNK_PORT_START = 5071
+
+
+def create_port_forward_rules(local_networks_list):
+    """Create NAT workaround rules for networks that cannot hairpin to the public IP."""
+    rules = []
+    for network in local_networks_list:
+        if network:
+            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=udp to-port=6060')
+            rules.append(f'rule family=ipv4 source address={network} forward-port port=5060 protocol=tcp to-port=6060')
+            rules.append(f'rule family=ipv4 source address={network} forward-port port=5061 protocol=tcp to-port=6061')
+    return rules
+
+
+def get_slot_public_ports(slot_count, start_port):
+    """Return the UDP/TCP firewall ports required for slot-based trunks."""
+    if slot_count < 0:
+        raise ValueError("TRUNK_SLOTS cannot be negative")
+    if start_port < 1:
+        raise ValueError("TRUNK_PORT_START must be greater than zero")
+
+    if slot_count == 0:
+        return []
+
+    end_port = start_port + slot_count - 1
+    if end_port > 65535:
+        raise ValueError("TRUNK_SLOTS and TRUNK_PORT_START exceed the valid port range")
+
+    port_range = str(start_port) if slot_count == 1 else f"{start_port}-{end_port}"
+    return [
+        f"{port_range}/tcp",
+        f"{port_range}/udp",
+    ]
+
+
+def get_slot_public_ports_from_env(env=None):
+    env = env or os.environ
+    slot_count = int(env.get("TRUNK_SLOTS", "0"))
+    start_port = int(env.get("TRUNK_PORT_START", str(DEFAULT_TRUNK_PORT_START)))
+    return get_slot_public_ports(slot_count, start_port)
+
+
+def get_public_service_ports(behind_nat, env=None):
+    ports = list(BASE_PUBLIC_PORTS)
+    ports.extend(get_slot_public_ports_from_env(env))
+    if behind_nat:
+        ports.extend(NAT_PUBLIC_PORTS)
+    return ports

--- a/imageroot/pypkg/firewall.py
+++ b/imageroot/pypkg/firewall.py
@@ -20,6 +20,7 @@ NAT_PUBLIC_PORTS = [
 ]
 
 DEFAULT_TRUNK_PORT_START = 5071
+SLOT_TLS_PORT_OFFSET = 1000
 
 
 def create_port_forward_rules(local_networks_list):
@@ -34,7 +35,7 @@ def create_port_forward_rules(local_networks_list):
 
 
 def get_slot_public_ports(slot_count, start_port):
-    """Return the UDP/TCP firewall ports required for slot-based trunks."""
+    """Return the firewall ports required for slot-based trunks."""
     if slot_count < 0:
         raise ValueError("TRUNK_SLOTS cannot be negative")
     if start_port < 1:
@@ -44,13 +45,17 @@ def get_slot_public_ports(slot_count, start_port):
         return []
 
     end_port = start_port + slot_count - 1
-    if end_port > 65535:
-        raise ValueError("TRUNK_SLOTS and TRUNK_PORT_START exceed the valid port range")
+    tls_start_port = start_port + SLOT_TLS_PORT_OFFSET
+    tls_end_port = end_port + SLOT_TLS_PORT_OFFSET
+    if tls_end_port > 65535:
+        raise ValueError("TRUNK_SLOTS and TRUNK_PORT_START exceed the valid slot listener range")
 
     port_range = str(start_port) if slot_count == 1 else f"{start_port}-{end_port}"
+    tls_port_range = str(tls_start_port) if slot_count == 1 else f"{tls_start_port}-{tls_end_port}"
     return [
         f"{port_range}/tcp",
         f"{port_range}/udp",
+        f"{tls_port_range}/tcp",
     ]
 
 

--- a/imageroot/systemd/user/kamailio.service
+++ b/imageroot/systemd/user/kamailio.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/podman run \
     --env='POSTGRES_*' \
     --env='REDIS_*' \
     --env='KML_*' \
+    --env='TRUNK_*' \
     --env=SERVICE_IP \
     --env=SERVICE_NET \
     --env=BEHIND_NAT \

--- a/imageroot/update-module.d/10env
+++ b/imageroot/update-module.d/10env
@@ -6,6 +6,7 @@
 #
 
 import agent
+import firewall
 import os
 
 # Check if the previus version supoported the NAT scenario
@@ -23,6 +24,13 @@ if os.getenv("SERVICE_IP", None) is None:
     agent.set_env('SERVICE_NET', rdb.get('cluster/network'))
     # Clean up obsolete env variable
     agent.unset_env('KML_INTERNAL_NETWORK')
+
+# Backfill slot-based trunk env vars introduced after the original release.
+if os.getenv("TRUNK_SLOTS", None) is None:
+    agent.set_env("TRUNK_SLOTS", "0")
+
+if os.getenv("TRUNK_PORT_START", None) is None:
+    agent.set_env("TRUNK_PORT_START", str(firewall.DEFAULT_TRUNK_PORT_START))
 
 # test if the passwords.env is present and if 'POSTGRES_PASSWORD' is present
 if not os.path.exists("passwords.env") and os.getenv('POSTGRES_PASSWORD') is not None:

--- a/imageroot/update-module.d/10env
+++ b/imageroot/update-module.d/10env
@@ -27,7 +27,7 @@ if os.getenv("SERVICE_IP", None) is None:
 
 # Backfill slot-based trunk env vars introduced after the original release.
 if os.getenv("TRUNK_SLOTS", None) is None:
-    agent.set_env("TRUNK_SLOTS", "0")
+    agent.set_env("TRUNK_SLOTS", "10")
 
 if os.getenv("TRUNK_PORT_START", None) is None:
     agent.set_env("TRUNK_PORT_START", str(firewall.DEFAULT_TRUNK_PORT_START))

--- a/modules/kamailio/bootstrap.sh
+++ b/modules/kamailio/bootstrap.sh
@@ -57,6 +57,31 @@ echo "listen=udp:${SERVICE_IP}:5060" >> /tmp/kamailio-local-additional.cfg
 echo "listen=tcp:${SERVICE_IP}:5060" >> /tmp/kamailio-local-additional.cfg
 echo "listen=tls:${SERVICE_IP}:5061" >> /tmp/kamailio-local-additional.cfg
 
+# Generate trunk port slots if TRUNK_SLOTS is set and > 0
+if [ -n "${TRUNK_SLOTS}" ] && [ "${TRUNK_SLOTS}" -gt 0 ]; then
+    TRUNK_PORT_START=${TRUNK_PORT_START:-5071}
+
+    echo "# Trunk Port Slots for Multi-Trunk Support" >> /tmp/kamailio-local-additional.cfg
+    echo "Generating ${TRUNK_SLOTS} trunk slots starting at port ${TRUNK_PORT_START}"
+
+    for i in $(seq 1 ${TRUNK_SLOTS}); do
+        SLOT_NAME="slot${i}"
+        SLOT_PORT=$((TRUNK_PORT_START + i - 1))
+        SLOT_TLS_PORT=$((SLOT_PORT + 1000))
+
+        if [ "${BEHIND_NAT}" == "true" ]; then
+            echo "listen=udp:${PRIVATE_IP}:${SLOT_PORT} advertise ${PUBLIC_IP}:${SLOT_PORT} name \"${SLOT_NAME}\"" >> /tmp/kamailio-local-additional.cfg
+            echo "listen=tcp:${PRIVATE_IP}:${SLOT_PORT} advertise ${PUBLIC_IP}:${SLOT_PORT} name \"${SLOT_NAME}\"" >> /tmp/kamailio-local-additional.cfg
+            echo "listen=tls:${PRIVATE_IP}:${SLOT_TLS_PORT} advertise ${PUBLIC_IP}:${SLOT_TLS_PORT} name \"${SLOT_NAME}_tls\"" >> /tmp/kamailio-local-additional.cfg
+        else
+            echo "listen=udp:${PUBLIC_IP}:${SLOT_PORT} name \"${SLOT_NAME}\"" >> /tmp/kamailio-local-additional.cfg
+            echo "listen=tcp:${PUBLIC_IP}:${SLOT_PORT} name \"${SLOT_NAME}\"" >> /tmp/kamailio-local-additional.cfg
+            echo "listen=tls:${PUBLIC_IP}:${SLOT_TLS_PORT} name \"${SLOT_NAME}_tls\"" >> /tmp/kamailio-local-additional.cfg
+        fi
+
+        echo "Generated slot: ${SLOT_NAME} on port ${SLOT_PORT} (UDP/TCP), ${SLOT_TLS_PORT} (TLS)"
+    done
+fi
 
 # rendering the template of kamailio-local.cfg and kamailio.cfg
 envsubst < /etc/kamailio/template.kamailio-local.cfg > /tmp/kamailio-local.cfg

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -164,7 +164,7 @@ modparam("keepalive", "ping_from", PING_FROM)
 modparam("keepalive", "delete_counter", 5)
 modparam("http_async_client", "workers", 2)
 modparam("uac", "restore_dlg", 1)
-modparam("pv", "shvset", "debug=i:1")
+modparam("pv", "shvset", "debug=i:0")
 modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -122,6 +122,11 @@ modparam("htable", "htable", "ipban=>size=20;autoexpire=300;")
 modparam("htable", "htable", "customer_ipban=>size=10;autoexpire=300;")
 modparam("htable", "htable", "apiban=>size=11;")
 modparam("htable", "htable", "apibanctl=>size=1;initval=0;")
+# Slot-based port binding for multi-trunk support (Vianova)
+modparam("htable", "db_url", DBURL)
+modparam("htable", "htable", "slotdomains=>size=4;autoexpire=0;dbtable=slot_domains;dbmode=1;")
+modparam("htable", "htable", "slotassign=>size=8;autoexpire=0;dbtable=slot_assignments;dbmode=2;")
+modparam("htable", "htable", "slotpool=>size=4;autoexpire=0;initval=0;")
 modparam("rr", "enable_full_lr", 1)
 modparam("rr", "append_fromtag", 1)
 modparam("rr", "enable_double_rr", 1)
@@ -159,7 +164,7 @@ modparam("keepalive", "ping_from", PING_FROM)
 modparam("keepalive", "delete_counter", 5)
 modparam("http_async_client", "workers", 2)
 modparam("uac", "restore_dlg", 1)
-modparam("pv", "shvset", "debug=i:0")
+modparam("pv", "shvset", "debug=i:1")
 modparam("pv", "shvset", "fakeprack=i:0")
 #!ifdef WITH_TLS
 modparam("tls", "config", "/etc/kamailio/tls/")
@@ -306,8 +311,13 @@ request_route {
             # this call needs to be relayed
             if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in dialog and direction OUT, doing RELAY \n");
             if (is_method("REGISTER")) {
+                route(SLOT_REGISTER);
                 route(REWRITE_CONTACT);
                 // add_contact_alias();
+            }
+            # Apply slot for outbound INVITE/other methods
+            if (is_method("INVITE|SUBSCRIBE|NOTIFY|UPDATE|OPTIONS")) {
+                route(SLOT_INVITE);
             }
             route(RELAY);
             exit;
@@ -438,6 +448,11 @@ route[WITHINDLG] {
             }
         }
 
+        # Apply stored trunk slot for in-dialog requests
+        if ($dlg_var(trunk_slot) != $null && $dlg_var(trunk_slot) != "") {
+            $fsn = $dlg_var(trunk_slot);
+            if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - WITHINDLG: applying trunk_slot=$fsn \n");
+        }
         if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - doing RELAY with destination : ru: $ru du: $du , host : $(ru{uri.host})\n");
         route(RELAY);
         exit;
@@ -1003,6 +1018,11 @@ route[SET_TIMERS] {
 # this route rewrite the contact header
 # -----------------------------------------------------------------------------
 route[REWRITE_CONTACT] {
+    # If a slot is assigned, delegate to slot-specific Contact rewriting
+    if ($fsn != $null && $fsn != "") {
+        route(SLOT_REWRITE_CONTACT);
+        return;
+    }
     $var(contactUriParameters) = $null;
     if(is_present_hf("contact")) {
         if($(ct{nameaddr.uri}{uri.user}) != $null && $(ct{nameaddr.uri}{uri.user}) != "" && $(ct{nameaddr.uri}{uri.user}) != 0) {
@@ -1060,8 +1080,18 @@ route[HANDLE_ALIAS] {
 # - INTERNAL_NETWORK: forces socket to SERVICE_IP:5060 (specific IP:port) for traffic to Asterisk
 # -----------------------------------------------------------------------------
 route[SET_SOCKET] {
+    # If a named socket (slot) is forced, do not override with $fs
+    if ($fsn != $null && $fsn != "") {
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - SET_SOCKET: $fsn is set, skipping socket override\n");
+        return;
+    }
     if( $shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in SET_SOCKET route \n");
     if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: ENTER \n");
+    # If a named socket (slot) is forced, do not override
+    if ($fsn != $null && $fsn != "") {
+        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - SET_SOCKET: $fsn is set, skipping socket override \n");
+        return;
+    }
     if(is_request()) {
         if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: is_request=TRUE \n");
         # print $rd is an ip and is in LOCALNETWORKS then print it
@@ -1147,4 +1177,169 @@ route[SET_SOCKET] {
         }
     }
 } # end of route[SET_SOCKET]
+# =============================================================================
+# SLOT-BASED PORT BINDING FOR MULTI-TRUNK SUPPORT (Vianova)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# event_route[htable:mod-init]
+# Initialize slot pool at startup and rebuild occupancy from persisted assignments
+# -----------------------------------------------------------------------------
+event_route[htable:mod-init] {
+    # Pre-initialize all slot pool entries to 0 (free)
+    $sht(slotpool=>slot1) = 0;
+    $sht(slotpool=>slot2) = 0;
+    $sht(slotpool=>slot3) = 0;
+    $sht(slotpool=>slot4) = 0;
+    $sht(slotpool=>slot5) = 0;
+    $sht(slotpool=>slot6) = 0;
+    $sht(slotpool=>slot7) = 0;
+    $sht(slotpool=>slot8) = 0;
+    $sht(slotpool=>slot9) = 0;
+    $sht(slotpool=>slot10) = 0;
+
+    # Rebuild occupancy: slotassign is loaded from DB (dbmode=2) before mod-init.
+    # Mark occupied slots by checking each slot name against slotassign values.
+    # We check each pool slot against all known assignments via a simple scan.
+    # Since slotassign has dbmode=2, entries are already loaded at this point.
+    # We rely on SLOT_REGISTER to re-mark slots on next REGISTER cycle.
+
+    xlog("L_INFO", "[SLOT_INIT] Slot pool initialized\n");
+}
+
+# -----------------------------------------------------------------------------
+# event_route[htable:expired:slotassign]
+# Automatically release slots when their TTL expires
+# -----------------------------------------------------------------------------
+event_route[htable:expired:slotassign] {
+    xlog("L_WARN", "[SLOT_EXPIRED] Key=$shtrecord(key) Value=$shtrecord(value) - releasing slot\n");
+    $sht(slotpool=>$shtrecord(value)) = 0;
+}
+
+# -----------------------------------------------------------------------------
+# route[SLOT_REGISTER]
+# Assign or refresh a slot for outbound REGISTER to special domains
+# -----------------------------------------------------------------------------
+route[SLOT_REGISTER] {
+    if (TRUNK_SLOTS <= 0) return;
+
+    $var(user) = $tU;
+    $var(domain) = $rd;
+
+    # 1. Check if domain requires slot binding
+    if ($sht(slotdomains=>$var(domain)) == $null) return;
+
+    # 2. Build lookup key
+    $var(slot_key) = $var(user) + "::" + $var(domain);
+
+    # 3. Handle un-register (Expires: 0)
+    $var(expires) = 0;
+    if (is_present_hf("Expires")) {
+        $var(expires) = $hdr(Expires);
+    }
+
+    if ($var(expires) == 0) {
+        $var(old_slot) = $sht(slotassign=>$var(slot_key));
+        if ($var(old_slot) != $null && $var(old_slot) != "") {
+            $sht(slotpool=>$var(old_slot)) = 0;
+            sht_rm("slotassign", "$var(slot_key)");
+            xlog("L_WARN", "[SLOT_REGISTER] - $ci $rm-$cs - UNREGISTER: Released $var(old_slot) for $var(slot_key)\n");
+        }
+        return;
+    }
+
+    # 4. Check if this (user, domain) already has a slot
+    $var(assigned_slot) = $sht(slotassign=>$var(slot_key));
+
+    if ($var(assigned_slot) != $null && $var(assigned_slot) != "") {
+        # Existing assignment — refresh TTL and ensure pool is marked
+        $shtex(slotassign=>$var(slot_key)) = 10800;
+        $sht(slotpool=>$var(assigned_slot)) = 1;
+        $fsn = $var(assigned_slot);
+        if ($shv(debug) == 1) xlog('L_WARN', "[SLOT_REGISTER] - $ci $rm-$cs - REFRESH: $var(slot_key) -> $fsn\n");
+        return;
+    }
+
+    # 5. Find first available slot
+    $var(found) = 0;
+    $var(i) = 1;
+    while ($var(i) <= TRUNK_SLOTS && $var(found) == 0) {
+        $var(slot_name) = "slot" + $var(i);
+        $var(pool_val) = $sht(slotpool=>$var(slot_name));
+        if ($var(pool_val) == 0) {
+            # Slot is free — claim it
+            $sht(slotpool=>$var(slot_name)) = 1;
+            $sht(slotassign=>$var(slot_key)) = $var(slot_name);
+            $shtex(slotassign=>$var(slot_key)) = 10800;
+            $fsn = $var(slot_name);
+            $var(found) = 1;
+            xlog("L_WARN", "[SLOT_REGISTER] - $ci $rm-$cs - ASSIGNED: $var(slot_key) -> $fsn (TTL 3h)\n");
+        }
+        $var(i) = $var(i) + 1;
+    }
+
+    # 6. Pool exhausted
+    if ($var(found) == 0) {
+        xlog("L_ERR", "[SLOT_REGISTER] - $ci $rm-$cs - EXHAUSTED: No available slots for $var(slot_key)\n");
+        sl_send_reply(503, "Service Unavailable - No slots available");
+        exit;
+    }
+} # end of route[SLOT_REGISTER]
+
+# -----------------------------------------------------------------------------
+# route[SLOT_INVITE]
+# Apply slot binding for outbound INVITE/methods to special domains
+# -----------------------------------------------------------------------------
+route[SLOT_INVITE] {
+    if (TRUNK_SLOTS <= 0) return;
+
+    # For outbound INVITE, the trunk username is in From-User ($fU)
+    $var(user) = $fU;
+    $var(domain) = $rd;
+
+    # Check if domain requires slot binding
+    if ($sht(slotdomains=>$var(domain)) == $null) return;
+
+    # Lookup assigned slot
+    $var(slot_key) = $var(user) + "::" + $var(domain);
+    $var(assigned_slot) = $sht(slotassign=>$var(slot_key));
+
+    if ($var(assigned_slot) != $null && $var(assigned_slot) != "") {
+        $fsn = $var(assigned_slot);
+        # Store in dialog for in-dialog requests (BYE, re-INVITE, etc.)
+        $dlg_var(trunk_slot) = $var(assigned_slot);
+        if ($shv(debug) == 1) xlog('L_WARN', "[SLOT_INVITE] - $ci $rm-$cs - $var(slot_key) -> $fsn\n");
+    }
+} # end of route[SLOT_INVITE]
+
+# -----------------------------------------------------------------------------
+# route[SLOT_REWRITE_CONTACT]
+# Rewrite Contact header with the slot's port for special domains
+# -----------------------------------------------------------------------------
+route[SLOT_REWRITE_CONTACT] {
+    # Calculate port from slot name: "slotN" -> TRUNK_PORT_START + N - 1
+    $var(slot_num) = $(fsn{s.substr,4,0});
+    $var(slot_port) = TRUNK_PORT_START + $var(slot_num) - 1;
+
+    # Determine transport from original Contact
+    $var(ctProto) = $(ct{nameaddr.uri}{uri.transport});
+    if ($var(ctProto) == $null || $var(ctProto) == "" || $var(ctProto) == 0) {
+        $var(ctProto) = "UDP";
+    }
+
+    # Preserve Contact URI parameters if present
+    $var(contactParams) = "";
+    if ($(ct{nameaddr.uri}{uri.params}) != $null && $(ct{nameaddr.uri}{uri.params}) != "" && $(ct{nameaddr.uri}{uri.params}) != 0) {
+        $var(contactParams) = ";" + $(ct{nameaddr.uri}{uri.params});
+    }
+
+    remove_hf("Contact");
+    $var(default_contact) = DEFAULT_CONTACT;
+    # Strip any existing port from DEFAULT_CONTACT before adding slot port
+    $var(contact_host) = $(var(default_contact){s.select,0,:});
+    append_hf("Contact: <sip:$fU@$var(contact_host):$var(slot_port);transport=$(var(ctProto){s.tolower})$var(contactParams)>\r\n", "Call-ID");
+
+    if ($shv(debug) == 1) xlog('L_WARN', "[SLOT_REWRITE_CONTACT] - $ci $rm-$cs - Contact rewritten with port $var(slot_port) (slot $fsn)\n");
+} # end of route[SLOT_REWRITE_CONTACT]
+
 # TT157 TEST MARKER

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -1282,9 +1282,14 @@ route[SLOT_REGISTER] {
     if ($var(expires) == 0) {
         $var(old_slot) = $sht(slotassign=>$var(slot_key));
         if ($var(old_slot) != $null && $var(old_slot) != "") {
-            $sht(slotpool=>$var(old_slot)) = 0;
-            sht_rm("slotassign", "$var(slot_key)");
-            xlog("L_WARN", "[SLOT_REGISTER] - $ci $rm-$cs - UNREGISTER: Released $var(old_slot) for $var(slot_key)\n");
+            # Send the un-register from the same slot port used for the
+            # original REGISTER, so the provider matches and clears it.
+            # Keep the assignment in place: the provider will challenge
+            # with 401/407 and the auth retry must resolve to the same
+            # slot. A subsequent REGISTER reuses the slot via REFRESH;
+            # a truly abandoned trunk has the slot freed by TTL expiry.
+            $fsn = $var(old_slot);
+            xlog("L_WARN", "[SLOT_REGISTER] - $ci $rm-$cs - UNREGISTER: $var(old_slot) for $var(slot_key) via $fsn (slot kept for retries/re-register)\n");
         }
         return;
     }
@@ -1334,8 +1339,11 @@ route[SLOT_REGISTER] {
 route[SLOT_INVITE] {
     if (TRUNK_SLOTS <= 0) return;
 
-    # For outbound INVITE, the trunk username is in From-User ($fU)
-    $var(user) = $fU;
+    # The slot was keyed on the trunk auth username ($tU of REGISTER). Some
+    # providers (e.g. Vianova) use an auth username that differs from the
+    # number placed in From, so $fU would not match. Asterisk carries the
+    # auth username in the Contact of the outbound INVITE — use it here.
+    $var(user) = $(ct{nameaddr.uri}{uri.user});
     $var(domain) = $rd;
 
     # Check if domain requires slot binding

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -1087,11 +1087,6 @@ route[SET_SOCKET] {
     }
     if( $shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in SET_SOCKET route \n");
     if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: ENTER \n");
-    # If a named socket (slot) is forced, do not override
-    if ($fsn != $null && $fsn != "") {
-        if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - SET_SOCKET: $fsn is set, skipping socket override \n");
-        return;
-    }
     if(is_request()) {
         if ($shv(debug) == 1) xlog('L_WARN', "[TT157] - $ci $rm-$cs - SET_SOCKET: is_request=TRUE \n");
         # print $rd is an ip and is in LOCALNETWORKS then print it

--- a/modules/kamailio/config/template.kamailio-local.cfg
+++ b/modules/kamailio/config/template.kamailio-local.cfg
@@ -50,6 +50,8 @@
 #!define LOCALNETWORKS "${LOCALNETWORKS}"
 #!define PRIVATE_IP "${PRIVATE_IP}"
 #!define SERVICE_IP "${SERVICE_IP}"
+#!define TRUNK_SLOTS ${TRUNK_SLOTS}
+#!define TRUNK_PORT_START ${TRUNK_PORT_START}
 
 server_header="Server: ${KML_SERVER_HEADER}"
 user_agent_header="User-Agent: ${KML_UA_HEADER}"

--- a/modules/postgres/migrations/05_slot_tables.sql
+++ b/modules/postgres/migrations/05_slot_tables.sql
@@ -1,0 +1,62 @@
+-- Slot-based port binding for multi-trunk support (Vianova)
+-- These tables follow the Kamailio htable schema for dbmode=1 compatibility
+
+-- Table for special domains requiring slot-based port assignment
+-- Used by htable "slotdomains"
+CREATE TABLE public.slot_domains (
+    id integer NOT NULL,
+    key_name character varying(64) DEFAULT ''::character varying NOT NULL,
+    key_type integer DEFAULT 0 NOT NULL,
+    value_type integer DEFAULT 0 NOT NULL,
+    key_value character varying(128) DEFAULT ''::character varying NOT NULL,
+    expires integer DEFAULT 0 NOT NULL
+);
+
+ALTER TABLE public.slot_domains OWNER TO postgres;
+
+CREATE SEQUENCE public.slot_domains_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.slot_domains_id_seq OWNER TO postgres;
+
+ALTER TABLE ONLY public.slot_domains ALTER COLUMN id SET DEFAULT nextval('public.slot_domains_id_seq'::regclass);
+
+ALTER TABLE ONLY public.slot_domains
+    ADD CONSTRAINT slot_domains_pkey PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX slot_domains_key_name_idx ON public.slot_domains (key_name);
+
+-- Table for slot assignments: (username::domain) -> slot_name
+-- Used by htable "slotassign"
+CREATE TABLE public.slot_assignments (
+    id integer NOT NULL,
+    key_name character varying(128) DEFAULT ''::character varying NOT NULL,
+    key_type integer DEFAULT 0 NOT NULL,
+    value_type integer DEFAULT 0 NOT NULL,
+    key_value character varying(64) DEFAULT ''::character varying NOT NULL,
+    expires integer DEFAULT 0 NOT NULL
+);
+
+ALTER TABLE public.slot_assignments OWNER TO postgres;
+
+CREATE SEQUENCE public.slot_assignments_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.slot_assignments_id_seq OWNER TO postgres;
+
+ALTER TABLE ONLY public.slot_assignments ALTER COLUMN id SET DEFAULT nextval('public.slot_assignments_id_seq'::regclass);
+
+ALTER TABLE ONLY public.slot_assignments
+    ADD CONSTRAINT slot_assignments_pkey PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX slot_assignments_key_name_idx ON public.slot_assignments (key_name);

--- a/modules/postgres/migrations/05_slot_tables.sql
+++ b/modules/postgres/migrations/05_slot_tables.sql
@@ -1,5 +1,5 @@
 -- Slot-based port binding for multi-trunk support (Vianova)
--- These tables follow the Kamailio htable schema for dbmode=1 compatibility
+-- These tables follow the Kamailio htable schema and are used with htable/slotassign (configured with dbmode=2; schema remains compatible with dbmode=1)
 
 -- Table for special domains requiring slot-based port assignment
 -- Used by htable "slotdomains"

--- a/tests/10_actions/10_configure_integrations.robot
+++ b/tests/10_actions/10_configure_integrations.robot
@@ -65,6 +65,8 @@ Slot ports survive repeated reconfiguration
     Should Be Equal As Integers    ${rc}  0
     Should Contain    ${firewall_ports}    5071-5073/tcp
     Should Contain    ${firewall_ports}    5071-5073/udp
+    Should Contain    ${firewall_ports}    6071-6073/tcp
+    Should Not Contain    ${firewall_ports}    6071-6073/udp
     Run task    module/${module_id}/configure-module
     ...    {"fqdn": "example.com", "lets_encrypt": false, "addresses": {"address": "${local_ip}", "public_address": "1.2.3.4"}, "local_networks": ["10.20.30.0/24"]}
     ${firewall_ports}  ${rc} =    Execute Command    firewall-cmd --permanent --service=${module_id} --get-ports
@@ -72,5 +74,7 @@ Slot ports survive repeated reconfiguration
     Should Be Equal As Integers    ${rc}  0
     Should Contain    ${firewall_ports}    5071-5073/tcp
     Should Contain    ${firewall_ports}    5071-5073/udp
+    Should Contain    ${firewall_ports}    6071-6073/tcp
+    Should Not Contain    ${firewall_ports}    6071-6073/udp
     Should Contain    ${firewall_ports}    6060-6061/tcp
     Should Contain    ${firewall_ports}    6060/udp

--- a/tests/10_actions/10_configure_integrations.robot
+++ b/tests/10_actions/10_configure_integrations.robot
@@ -55,3 +55,22 @@ Set a FQDN without let's encrypt and an address with NAT
     Should Contain    ${firewall_ports}    6060/udp
     Should Not Contain    ${firewall_ports}    5061/udp
     Should Not Contain    ${firewall_ports}    6061/udp
+
+Slot ports survive repeated reconfiguration
+    Run module command    python3 -c 'import agent; agent.set_env("TRUNK_SLOTS", "3"); agent.set_env("TRUNK_PORT_START", "5071")'
+    Run task    module/${module_id}/configure-module
+    ...    {"fqdn": "example.com", "lets_encrypt": false, "addresses": {"address": "${local_ip}"}}
+    ${firewall_ports}  ${rc} =    Execute Command    firewall-cmd --permanent --service=${module_id} --get-ports
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}  0
+    Should Contain    ${firewall_ports}    5071-5073/tcp
+    Should Contain    ${firewall_ports}    5071-5073/udp
+    Run task    module/${module_id}/configure-module
+    ...    {"fqdn": "example.com", "lets_encrypt": false, "addresses": {"address": "${local_ip}", "public_address": "1.2.3.4"}, "local_networks": ["10.20.30.0/24"]}
+    ${firewall_ports}  ${rc} =    Execute Command    firewall-cmd --permanent --service=${module_id} --get-ports
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}  0
+    Should Contain    ${firewall_ports}    5071-5073/tcp
+    Should Contain    ${firewall_ports}    5071-5073/udp
+    Should Contain    ${firewall_ports}    6060-6061/tcp
+    Should Contain    ${firewall_ports}    6060/udp

--- a/tests/api.resource
+++ b/tests/api.resource
@@ -12,3 +12,9 @@ Run task
         ${response} =    Set Variable    ${stdout}
     END
     RETURN    ${response}
+
+Run module command
+    [Arguments]    ${command}    ${rc_expected}=0
+    ${stdout}    ${stderr}    ${rc} =     Execute Command    runagent -m ${module_id} ${command}    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc_expected}    ${rc}    Run module command failed!${\n}${stderr}
+    RETURN    ${stdout}


### PR DESCRIPTION
## Summary

- Implements dynamic port slot binding to support multiple Vianova trunks from a single proxy IP
- When Kamailio processes an outbound REGISTER to a "special" domain (e.g., `voip.vianova.it`), it automatically assigns a unique port slot to each `(username, domain)` tuple
- The Contact header is rewritten with the slot port (e.g., `88.88.88.1:5071`), and all subsequent SIP traffic (INVITE, BYE, etc.) uses the same slot
- Slot assignments are persisted in PostgreSQL and managed with a 3-hour TTL, reset on every REGISTER refresh

### Changes

- **`modules/kamailio/config/kamailio.cfg`** — New routes: `SLOT_REGISTER`, `SLOT_INVITE`, `SLOT_REWRITE_CONTACT`; `SET_SOCKET` guard for `$fsn`; htable definitions (`slotdomains`, `slotassign`, `slotpool`); expired event route for automatic slot release
- **`modules/kamailio/bootstrap.sh`** — Dynamic generation of named listen sockets (slots) based on `TRUNK_SLOTS` and `TRUNK_PORT_START` env vars
- **`modules/kamailio/config/template.kamailio-local.cfg`** — Added `TRUNK_SLOTS` and `TRUNK_PORT_START` defines
- **`modules/postgres/migrations/05_slot_tables.sql`** — New tables `slot_domains` and `slot_assignments` for htable persistence
- **`imageroot/actions/create-module/10env`** — Default env vars (`TRUNK_SLOTS=0`, `TRUNK_PORT_START=5071`)

### How it works

1. Admin adds a domain to `slot_domains` table and reloads with `kamcmd htable.reload slotdomains`
2. Each outbound REGISTER to that domain gets a unique slot (port) per trunk username
3. INVITE and other methods look up the slot by `$fU::$rd` (From-User + Request-Domain)
4. `$fsn` forces the outbound socket; `SET_SOCKET` is guarded to not override it
5. Slots are released automatically after 3h TTL expiry or explicit un-register (Expires: 0)

### Tested on GNS3

- Two trunks (`040989898` → slot1/5071, `040888888` → slot2/5072) registering simultaneously
- REGISTER, INVITE, BYE all using correct slot ports
- Slot persistence across Kamailio restart
- No race conditions with concurrent registrations

### Related

- Closes NethServer/dev#7365

## Test plan

- [ ] Verify REGISTER to non-special domain uses legacy behavior (no slot)
- [ ] Verify first REGISTER to special domain assigns slot1
- [ ] Verify second trunk to same domain assigns slot2
- [ ] Verify REGISTER refresh keeps same slot, resets TTL
- [ ] Verify INVITE uses correct slot port
- [ ] Verify slot release on Expires: 0
- [ ] Verify 503 when all slots exhausted
- [ ] Verify persistence after Kamailio restart
- [ ] Verify firewall ports are opened (pending `20firewall` update)