### PR TITLE
fix: preserve local networks in ui

### DIFF
--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -492,7 +492,6 @@ export default {
         interfaces.push({
           name: iface.name,
           label: label,
-          network: iface.addresses[0].network,
           value: interfacesAddress,
         });
       }
@@ -577,11 +576,12 @@ export default {
       // check if public_address exists and is different from local ip address
       if (this.address && this.address !== this.iface) {
         dataPayload.addresses.public_address = this.address;
-
-        const additionalLocalNetworks =
-          this.getAdditionalLocalNetworks(currentConfig);
-        if (additionalLocalNetworks.length) {
-          dataPayload.local_networks = additionalLocalNetworks;
+        const localNetworks =
+          currentConfig && Array.isArray(currentConfig.local_networks)
+            ? [...currentConfig.local_networks]
+            : [];
+        if (localNetworks.length) {
+          dataPayload.local_networks = localNetworks;
         }
       }
 
@@ -692,38 +692,6 @@ export default {
           reject(err);
         });
       });
-    },
-    getInterfaceNetwork(address) {
-      if (!address || !this.interfaces || !this.interfaces.length) {
-        return "";
-      }
-
-      const selectedInterface = this.interfaces.find(
-        (iface) => iface.value === address
-      );
-      return selectedInterface && selectedInterface.network
-        ? selectedInterface.network
-        : "";
-    },
-    getAdditionalLocalNetworks(config = this.config) {
-      const localNetworks =
-        config && Array.isArray(config.local_networks)
-          ? config.local_networks
-          : [];
-
-      if (!localNetworks.length) {
-        return [];
-      }
-
-      const selectedInterfaceNetwork = this.getInterfaceNetwork(this.iface);
-
-      if (!selectedInterfaceNetwork) {
-        return [...localNetworks];
-      }
-
-      return localNetworks.filter(
-        (network) => network !== selectedInterfaceNetwork
-      );
     },
     goToCertificates() {
       this.core.$router.push("/settings/tls-certificates");

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -489,6 +489,7 @@ export default {
         interfaces.push({
           name: iface.name,
           label: label,
+          network: iface.addresses[0].network,
           value: interfacesAddress,
         });
       }
@@ -560,6 +561,11 @@ export default {
       // check if public_address exists and is different from local ip address
       if (this.address && this.address !== this.iface) {
         dataPayload.addresses.public_address = this.address;
+
+        const additionalLocalNetworks = this.getAdditionalLocalNetworks();
+        if (additionalLocalNetworks.length) {
+          dataPayload.local_networks = additionalLocalNetworks;
+        }
       }
 
       const res = await to(
@@ -640,6 +646,38 @@ export default {
     getStatusCompleted(taskContext, taskResult) {
       this.status = taskResult.output;
       this.loading.getStatus = false;
+    },
+    getInterfaceNetwork(address) {
+      if (!address || !this.interfaces || !this.interfaces.length) {
+        return "";
+      }
+
+      const selectedInterface = this.interfaces.find(
+        (iface) => iface.value === address
+      );
+      return selectedInterface && selectedInterface.network
+        ? selectedInterface.network
+        : "";
+    },
+    getAdditionalLocalNetworks(config = this.config) {
+      const localNetworks =
+        config && Array.isArray(config.local_networks)
+          ? config.local_networks
+          : [];
+
+      if (!localNetworks.length) {
+        return [];
+      }
+
+      const selectedInterfaceNetwork = this.getInterfaceNetwork(this.iface);
+
+      if (!selectedInterfaceNetwork) {
+        return [...localNetworks];
+      }
+
+      return localNetworks.filter(
+        (network) => network !== selectedInterfaceNetwork
+      );
     },
     goToCertificates() {
       this.core.$router.push("/settings/tls-certificates");

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -307,16 +307,7 @@ export default {
         this.getConfigurationCompleted
       );
 
-      const res = await to(
-        this.createModuleTaskForApp(this.instanceName, {
-          action: taskAction,
-          extra: {
-            title: this.$t("action." + taskAction),
-            isNotificationHidden: true,
-            eventId,
-          },
-        })
-      );
+      const res = await to(this.createGetConfigurationTask(eventId));
       const err = res[0];
 
       if (err) {
@@ -349,6 +340,18 @@ export default {
 
       // focus first configuration field
       this.focusElement("fqdn");
+    },
+    createGetConfigurationTask(eventId) {
+      const taskAction = "get-configuration";
+
+      return this.createModuleTaskForApp(this.instanceName, {
+        action: taskAction,
+        extra: {
+          title: this.$t("action." + taskAction),
+          isNotificationHidden: true,
+          eventId,
+        },
+      });
     },
     validateConfigureModule() {
       this.clearErrors(this);
@@ -528,8 +531,21 @@ export default {
       }
 
       this.loading.configureModule = true;
+      this.error.configureModule = "";
       const taskAction = "configure-module";
       const eventId = this.getUuid();
+      let currentConfig = this.config;
+
+      if (this.address && this.address !== this.iface) {
+        try {
+          currentConfig = await this.fetchCurrentConfiguration();
+        } catch (error) {
+          console.warn(
+            "error fetching current configuration, using cached configuration",
+            error
+          );
+        }
+      }
 
       // register to task error
       this.core.$root.$once(
@@ -562,7 +578,8 @@ export default {
       if (this.address && this.address !== this.iface) {
         dataPayload.addresses.public_address = this.address;
 
-        const additionalLocalNetworks = this.getAdditionalLocalNetworks();
+        const additionalLocalNetworks =
+          this.getAdditionalLocalNetworks(currentConfig);
         if (additionalLocalNetworks.length) {
           dataPayload.local_networks = additionalLocalNetworks;
         }
@@ -646,6 +663,35 @@ export default {
     getStatusCompleted(taskContext, taskResult) {
       this.status = taskResult.output;
       this.loading.getStatus = false;
+    },
+    async fetchCurrentConfiguration() {
+      const taskAction = "get-configuration";
+      const eventId = this.getUuid();
+      const abortedEvent = `${taskAction}-aborted-${eventId}`;
+      const completedEvent = `${taskAction}-completed-${eventId}`;
+
+      return new Promise((resolve, reject) => {
+        const cleanup = () => {
+          this.core.$root.$off(abortedEvent, onAborted);
+          this.core.$root.$off(completedEvent, onCompleted);
+        };
+        const onAborted = (taskResult) => {
+          cleanup();
+          reject(taskResult);
+        };
+        const onCompleted = (taskContext, taskResult) => {
+          cleanup();
+          resolve(taskResult.output);
+        };
+
+        this.core.$root.$once(abortedEvent, onAborted);
+        this.core.$root.$once(completedEvent, onCompleted);
+
+        this.createGetConfigurationTask(eventId).catch((err) => {
+          cleanup();
+          reject(err);
+        });
+      });
     },
     getInterfaceNetwork(address) {
       if (!address || !this.interfaces || !this.interfaces.length) {


### PR DESCRIPTION
## Summary

This PR fixes Settings saves for NAT deployments that use additional local networks added from the cli. Without resending `local_networks`, a normal save can drop manually added subnets and make the proxy stop treating those clients as local.

The Settings page now keeps the extra networks already stored in the module configuration, filters out the selected interface subnet so only true additions are preserved, and refreshes the live config before saving so a stale page does not overwrite changes made elsewhere. If the refresh fails, the save still falls back to the cached page state instead of failing.

## How to test
1. Install current branch module `add-module ghcr.io/nethesis/nethvoice-proxy:fix-preserve-local-networks-ui`
2. Configure a NAT deployment
3. Add an extra network via `api-cli`,  eg, get current config `api-cli run module/nethvoice-proxy3/get-configuration` edit and reapply  the configs  `api-cli run module/nethvoice-proxy3/configure-module -d ...`
4. Save the module from Settings
5. Verify via `api-cli` that all previously added subnets stay in the configuration.

## Related discussion

Mattermost Chat: https://mattermost.nethesis.it/nethesis/pl/kcfpinp9opnn5m4iwns8hzqwtc