### PR TITLE
fix(kamailio): SET_SOCKET reply use $si instead of $dlg_var(source_ip) (#445)

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -1182,9 +1182,12 @@ route[SET_SOCKET] {
                     # logging rtpengine_conf
                     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
                 }
-                # Handle reply to INTERNAL_NETWORK (service network)
-                if (is_in_subnet($var(destination_ip), INTERNAL_NETWORK)) {
-                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - reply destination ip is in INTERNAL_NETWORK \n");
+                # Use the source IP of THIS reply ($si) to decide the rtpengine direction,
+                # not $dlg_var(source_ip) which is fixed at INVITE time and is wrong for
+                # in-dialog UPDATEs that flow against the original dialog direction.
+                # If $si is external the reply travels toward internal Asterisk -> rewrite needed.
+                if (!is_in_subnet($si, INTERNAL_NETWORK) && $si != "127.0.0.1") {
+                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - reply source $si is external, reply travels toward INTERNAL_NETWORK \n");
                     # replace external in rtpengine_conf with internal
                     $var(rtpengine_conf) = $(var(rtpengine_conf){s.replace,external,internal});
                     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");


### PR DESCRIPTION
## Summary

Fix for "UPDATE in-call causing audio loss" reported in helpdesk ticket #445

In `route[SET_SOCKET]` branch `is_reply` the rewrite `external -> internal` on `$var(rtpengine_conf)` was driven by `$dlg_var(source_ip)`, which is set once at the initial `INVITE` of the dialog. For an outbound call this value always points to the internal NethVoice IP (`SERVICE_IP`), so the condition matched for any in-dialog reply regardless of the actual direction of that single SIP transaction.

For the `200 OK` of an `UPDATE` originated by the upstream provider this caused the rtpengine config to flip from `direction=internal direction=external` (correctly set by `NATMANAGE`) to `direction=internal direction=internal`. rtpengine no longer rewrote the SDP origin and the `200 OK` was forwarded back to the provider with `c=IN IP4 <SERVICE_IP>` instead of the proxy public IP — leading to an RTP black hole and silent audio.

Fix: use `$si` (source IP of the current reply) to decide direction. If `$si` is external the reply is heading toward the internal Asterisk, so the `external -> internal` rewrite is required; if `$si` is internal the reply is leaving toward the external caller and the rewrite must be skipped (`NATMANAGE` has already set the correct direction).

## Diff

```diff
@@ route[SET_SOCKET]  is_reply branch  (modules/kamailio/config/kamailio.cfg)
-                # Handle reply to INTERNAL_NETWORK (service network)
-                if (is_in_subnet($var(destination_ip), INTERNAL_NETWORK)) {
-                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - reply destination ip is in INTERNAL_NETWORK \n");
+                # Use the source IP of THIS reply ($si) to decide the rtpengine direction,
+                # not $dlg_var(source_ip) which is fixed at INVITE time and is wrong for
+                # in-dialog UPDATEs that flow against the original dialog direction.
+                # If $si is external the reply travels toward internal Asterisk -> rewrite needed.
+                if (!is_in_subnet($si, INTERNAL_NETWORK) && $si != "127.0.0.1") {
+                    if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - reply source $si is external, reply travels toward INTERNAL_NETWORK \n");
                     # replace external in rtpengine_conf with internal
                     $var(rtpengine_conf) = $(var(rtpengine_conf){s.replace,external,internal});
                     if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - rtpengine_conf: $var(rtpengine_conf) \n");
                 }
```

Functional change is a single condition swap, scoped to the `is_reply` branch of `SET_SOCKET`. No impact on `request_route`, `MANAGE_REPLY`, `NATMANAGE` or the `is_request` branch of `SET_SOCKET`.

## Test plan

Reproduced on a GNS3 lab: `nethserver-under-nat.gns3.evoseed.it` running `ns8-nethvoice-proxy` 1.5.0, FreePBX acting as the upstream provider, dialplan `demo-test-update` issuing `PJSIP_SEND_SESSION_REFRESH=update` from the callee side to mimic the ticket scenario.

- [x] Pre-patch repro: `200 OK UPDATE` proxy → provider carries `c=IN IP4 10.5.4.1` port `11070` (matches frame 22 of the pcap attached to the ticket).
- [x] Patched cfg + `podman restart kamailio`: `200 OK UPDATE` proxy → provider carries `c=IN IP4 88.88.88.1` (the proxy `PUBLIC_IP`) consistently across 3 consecutive runs.
- [x] Regression — plain outbound call (no `UPDATE`): outbound `INVITE` with `c=88.88.88.1`, `200 OK` to Asterisk with `c=10.5.4.1`, `BYE` and `OPTIONS` flow unchanged.
- [x] Regression — inbound call from provider: `INVITE` rewritten with `c=10.5.4.1` toward Asterisk, `180 Ringing` relayed back to the provider correctly.
- [x] Validation on the customer environment that originated the ticket (Nethesis — coopvoce calls and toll-free numbers).

Refs: helpdesk ticket #445