### PR TITLE
ci(workflows): add pr testing image workflow

### DIFF
--- a/.github/workflows/create-testing-pr-image.yml
+++ b/.github/workflows/create-testing-pr-image.yml
@@ -1,0 +1,60 @@
+name: NS8 PR Testing Image
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'tests/**'
+      - 'README.md'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'renovate.json'
+      - 'test-module.sh'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  tagname:
+    name: Compute image tag
+    runs-on: ubuntu-latest
+    outputs:
+      imagetag: ${{ steps.imagetag.outputs.imagetag }}
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Compute image tag
+        id: imagetag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          short_sha="${MERGE_SHA::7}"
+          echo "imagetag=pr-${PR_NUMBER}.${RUN_NUMBER}-${RUN_ATTEMPT}.${short_sha}" >> "$GITHUB_OUTPUT"
+  create-testing-pr-image:
+    name: Create testing PR image
+    needs: tagname
+    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    with:
+      imagetag: ${{ needs.tagname.outputs.imagetag }}
+  comment-pr:
+    needs: [tagname, create-testing-pr-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment PR with image URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IMAGETAG: ${{ needs.tagname.outputs.imagetag }}
+        run: |
+          reponame="${{ github.event.repository.name }}"
+          # Strip the ns8- prefix from the repo name
+          reponame="${reponame#ns8-}"
+          image_url="ghcr.io/${{ github.repository_owner }}/${reponame}:${IMAGETAG}"
+          gh pr comment -R ${{ github.repository }} "${PR_NUMBER}" --body "🔨 PR testing image: \`${image_url}\`"


### PR DESCRIPTION
Add a GitHub Actions workflow triggered on pull requests (excluding docs/config/tests) that:
- Computes a testing image tag based on PR number, run number, and merge SHA
- Triggers the reusable publish-branch workflow from NethServer/ns8-github-actions
- Comments on the PR with the published ghcr.io image URL