### PR TITLE
test: add ui coverage for local networks

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Run tests"
     uses: NethServer/ns8-github-actions/.github/workflows/test-module.yml@v1
     with:
-      ui_tests_strategy: on_renovate_ui_change
+      ui_tests_strategy: on_ui_change
       debug_shell: ${{ github.event.inputs.debug_shell == 'true' }}
     secrets:
       do_token: ${{ secrets.do_token }}

--- a/tests/05_ui.robot
+++ b/tests/05_ui.robot
@@ -1,34 +1,15 @@
 *** Settings ***
-Library           Browser
-
-*** Variables ***
-${ADMIN_USER}    admin
-${ADMIN_PASSWORD}    Nethesis,1234
-${module_id}    ${EMPTY}
-
-*** Keywords ***
-
-Login to cluster-admin
-    New Page    https://${NODE_ADDR}/cluster-admin/
-    Fill Text    text="Username"    ${ADMIN_USER}
-    Click    button >> text="Continue"
-    Fill Text    text="Password"    ${ADMIN_PASSWORD}
-    Click    button >> text="Log in"
-    Wait For Elements State    css=#main-content    visible    timeout=10s
+Resource    ui.resource
+Suite Teardown    Run Keyword And Ignore Error    Close Browser
 
 *** Test Cases ***
 
 Take screenshots
     [Tags]    ui
-    New Browser    chromium    headless=True
-    New Context    ignoreHTTPSErrors=True
-    Login to cluster-admin
-    Go To    https://${NODE_ADDR}/cluster-admin/#/apps/${module_id}
-    Wait For Elements State    iframe >>> h2 >> text="Status"    visible    timeout=10s
+    Open Browser To Cluster Admin    ${NODE_ADDR}
+    Open App Status Page    ${NODE_ADDR}    ${module_id}
     Sleep    5s
     Take Screenshot    filename=${OUTPUT DIR}/browser/screenshot/1._Status.png
-    Go To    https://${NODE_ADDR}/cluster-admin/#/apps/${module_id}?page=settings
-    Wait For Elements State    iframe >>> h2 >> text="Settings"    visible    timeout=10s
+    Open App Settings Page    ${NODE_ADDR}    ${module_id}
     Sleep    5s
     Take Screenshot    filename=${OUTPUT DIR}/browser/screenshot/2._Settings.png
-    Close Browser

--- a/tests/11_preserve_local_networks_ui.robot
+++ b/tests/11_preserve_local_networks_ui.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Resource    api.resource
+Resource    ui.resource
+Suite Teardown    Run Keyword And Ignore Error    Close Browser
+
+*** Test Cases ***
+Preserve local networks after saving settings
+    [Tags]    ui
+    Run task    module/${module_id}/configure-module
+    ...    {"fqdn": "before.example.com", "lets_encrypt": false, "addresses": {"address": "${local_ip}", "public_address": "1.2.3.4"}, "local_networks": ["10.20.30.0/24"]}
+    ${before} =    Run task    module/${module_id}/get-configuration    {}
+    Should Be Equal    ${before["fqdn"]}    before.example.com
+    Should Be Equal
+    ...    ${before["addresses"]}
+    ...    ${{ {"address": "${local_ip}", "public_address": "1.2.3.4"} }}
+    Should Contain    ${before["local_networks"]}    ${local_network}
+    Should Contain    ${before["local_networks"]}    10.20.30.0/24
+
+    Open Browser To Cluster Admin    ${NODE_ADDR}
+    Open App Settings Page    ${NODE_ADDR}    ${module_id}
+    Save Settings Form
+    Assert No Settings Errors
+
+    ${after} =    Run task    module/${module_id}/get-configuration    {}
+    Should Be Equal    ${after["fqdn"]}    before.example.com
+    Should Be Equal
+    ...    ${after["addresses"]}
+    ...    ${{ {"address": "${local_ip}", "public_address": "1.2.3.4"} }}
+    Should Contain    ${after["local_networks"]}    ${local_network}
+    Should Contain    ${after["local_networks"]}    10.20.30.0/24

--- a/tests/ui.resource
+++ b/tests/ui.resource
@@ -1,0 +1,58 @@
+*** Settings ***
+Library    Browser
+Library    OperatingSystem
+
+*** Keywords ***
+Open Browser To Cluster Admin
+    [Arguments]    ${node_addr}
+    New Browser    chromium    headless=True
+    New Context    ignoreHTTPSErrors=True
+    New Page    https://${node_addr}/cluster-admin/
+    Login To Cluster Admin
+
+Login To Cluster Admin
+    ${admin_user} =    Get Environment Variable    ADMIN_USER    admin
+    ${admin_password} =    Get Environment Variable    ADMIN_PASSWORD    Nethesis,1234
+    Wait For Elements State    css=input[name="username"]    visible    timeout=20s
+    Fill Text    css=input[name="username"]    ${admin_user}
+    Click    css=.login-button
+    Wait For Elements State    css=input[type="password"]    visible    timeout=20s
+    Fill Text    css=input[type="password"]    ${admin_password}
+    Click    css=.login-button
+    Wait For Elements State    css=#main-content    visible    timeout=20s
+
+Open App Status Page
+    [Arguments]    ${node_addr}    ${module_id}
+    Go To    https://${node_addr}/cluster-admin/#/apps/${module_id}
+    Wait For Elements State    iframe >>> css=.page-title h2    visible    timeout=30s
+    Get Text    iframe >>> css=.page-title h2    ==    Status
+    Wait For Elements State
+    ...    iframe >>> css=.page-subtitle h4 >> nth=0
+    ...    visible
+    ...    timeout=30s
+
+Open App Settings Page
+    [Arguments]    ${node_addr}    ${module_id}
+    Go To    https://${node_addr}/cluster-admin/#/apps/${module_id}?page=settings
+    Wait For Elements State    iframe >>> css=.page-title h2    visible    timeout=30s
+    Get Text    iframe >>> css=.page-title h2    ==    Settings
+    Wait For Elements State    iframe >>> css=form    visible    timeout=30s
+    Wait For Elements State
+    ...    iframe >>> css=form button.bx--btn--primary
+    ...    enabled
+    ...    timeout=30s
+
+Save Settings Form
+    Click    iframe >>> css=form button.bx--btn--primary
+    Wait For Elements State
+    ...    iframe >>> css=form button.bx--btn--primary
+    ...    disabled
+    ...    timeout=10s
+    Wait For Elements State
+    ...    iframe >>> css=form button.bx--btn--primary
+    ...    enabled
+    ...    timeout=90s
+
+Assert No Settings Errors
+    ${errors} =    Get Element Count    iframe >>> css=.bx--inline-notification--error
+    Should Be Equal As Integers    ${errors}    0


### PR DESCRIPTION
## Summary

Add UI test coverage for the Settings save flow introduced in #165.

This stacked PR hardens the existing Browser smoke test so it does not
rely on English labels, allows manual QA to override cluster-admin
credentials when needed, enables UI suites on any UI change, and adds a
Robot Framework regression test that verifies `local_networks` are
preserved after saving a NAT configuration from the Settings page.

## Related issue

N/A (stacked follow-up for PR test coverage)

## How to test

1. Run the Browser UI smoke test on a localized cluster-admin instance.
2. Run the new `tests/11_preserve_local_networks_ui.robot` suite against
   the PR image from #165.
3. Verify the Settings save keeps the existing `local_networks` values in
   `get-configuration` after a NAT configuration is saved.

## Dependencies

- nethesis/ns8-nethvoice-proxy#165
