### PR TITLE
fix: upgrade base libraries to reduce crashes

### DIFF
--- a/modules/kamailio/Dockerfile
+++ b/modules/kamailio/Dockerfile
@@ -8,6 +8,8 @@ ENV TZ="Europe/Rome"
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV KAMAILIO_VERSION="5.8.8"
 
+
+RUN apt-get update && apt-get upgrade --no-install-recommends --assume-yes && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install --no-install-recommends --assume-yes gnupg wget && rm -rf /var/lib/apt/lists/*
 RUN echo "deb http://deb.kamailio.org/kamailio58 noble main" > /etc/apt/sources.list.d/kamailio.list
 RUN wget -O- http://deb.kamailio.org/kamailiodebkey.gpg | apt-key add -


### PR DESCRIPTION
## Summary

Upgrade the base Ubuntu packages in the Kamailio image before
installing dependencies to pick up updated shared libraries that may
reduce the Kamailio/libssl crashes seen in production.

The updated packages include:
- libgcrypt20
- libgnutls30t64
- liblzma5
- libssl3t64
- libsystemd0
- libudev1

A sample coredump shows the crash path crossing Kamailio TLS modules
and OpenSSL/libcrypto, so this change is intended as a low-risk image
refresh to validate whether newer system libraries improve stability.

## Related issue

No linked issue yet.

## How to test

1. Build and publish the updated kamailio image from this branch.
2. Deploy it in an environment affected by the crash.
3. Exercise TLS/SIP traffic that previously triggered the failure.
4. Monitor Kamailio stability and verify no new coredumps are produced.
5. Confirm the container includes the upgraded Ubuntu packages.

## Dependencies

None.
