### PR TITLE
Implement loopback detection and Call-ID masking for trunk scenarios

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -432,6 +432,34 @@ route[WITHINDLG] {
             # Ensure correct socket is used for ACKs across all relevant network types
             route(SET_SOCKET);
             route(NATMANAGE);
+
+            # WORKAROUND topos+mask_callid (ticket 430, Kamailio issue #4208 "not planned"):
+            # topos ricostruisce l'ACK 2xx lato trunk-out come Request-URI =
+            # Record-Route (con ;lr) e niente Route header. Un upstream stateless
+            # (es. Kamailio Retelit) lo droppa silenziosamente: il callee
+            # ritrasmette il 200 OK fino a timeout T1 (32s) e la chiamata cade.
+            # Strategia: forwardiamo noi l'ACK con forward() stateless usando
+            # Contact UAS + Record-Route memorizzati in onreply_route quando
+            # era arrivato il 200 OK dal trunk (dlg_var out_contact / out_rr).
+            # forward() bypassa interamente la pipeline topos (no rebuild),
+            # mentre t_relay() avrebbe re-triggerato il collapse rotto.
+            if ($dlg_var(direction) == "out" && $dlg_var(out_contact) != $null) {
+                $var(uas_uri) = $(dlg_var(out_contact){nameaddr.uri});
+                if ($var(uas_uri) == $null) {
+                    $var(uas_uri) = $dlg_var(out_contact);
+                }
+                $ru = $var(uas_uri);
+                remove_hf("Route");
+                if ($dlg_var(out_rr) != $null) {
+                    $var(rr_uri) = $(dlg_var(out_rr){nameaddr.uri});
+                    if ($var(rr_uri) != $null) {
+                        append_hf("Route: <$var(rr_uri)>\r\n");
+                    }
+                }
+                if ($shv(debug) == 1) xlog('L_WARN', "[FIX430] ACK trunk-out forced ru=$ru rr=$dlg_var(out_rr) - stateless forward \n");
+                forward();
+                exit;
+            }
         } else if ( is_method("NOTIFY") ) {
             # Add Record-Route for in-dialog NOTIFY as per RFC 6665.
             record_route();
@@ -834,7 +862,7 @@ onreply_route[MANAGE_REPLY] {
     if ($rs=~"[12][0-9][0-9]|488") {
         if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in reply route (MANAGE_REPLY) and Response code is: $rs \n");
         # handling avp and dlg_var direction
-        # printing $si 
+        # printing $si
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - si: $si, rs: $rs \n");
         # $si is correctly set, to 10.5.4.1
         # setting direction in opposite (as it's a reply)
@@ -845,6 +873,17 @@ onreply_route[MANAGE_REPLY] {
         }
         $dlg_var(direction) = $avp(direction);
         if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - REPLY: Setting direction to :  $avp(direction)\n");
+
+        # WORKAROUND topos+mask_callid (ticket 430): salviamo Contact UAS e
+        # Record-Route ricevuti dal trunk per ricostruire manualmente l'ACK
+        # end-to-end nella route[WITHINDLG] (vedi commento li`).
+        if ($rs =~ "2[0-9][0-9]" && $avp(direction) == "out" && $ct != $null) {
+            $dlg_var(out_contact) = $ct;
+            if ($hdr(Record-Route) != $null) {
+                $dlg_var(out_rr) = $hdr(Record-Route);
+            }
+            if ($shv(debug) == 1) xlog('L_WARN', "[FIX430] reply out 2xx: saved out_contact=$ct out_rr=$hdr(Record-Route) \n");
+        }
 
         route(NATMANAGE);
     }

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -123,6 +123,12 @@ modparam("htable", "htable", "ipban=>size=20;autoexpire=300;")
 modparam("htable", "htable", "customer_ipban=>size=10;autoexpire=300;")
 modparam("htable", "htable", "apiban=>size=11;")
 modparam("htable", "htable", "apibanctl=>size=1;initval=0;")
+# loopback: mappa per detection di chiamate trunk-to-trunk riflesse dallo
+# stesso provider (ticket 430). Chiave = From-tag (invariante end-to-end),
+# valore = CID/Contact/To-tag delle due dialog associate (caller-side e
+# callee-side), per cross-dialog rewriting di BYE/in-dialog in WITHINDLG.
+# autoexpire 3600s = TTL ragionevole per dialog non chiuse correttamente.
+modparam("htable", "htable", "loopback=>size=10;autoexpire=3600;")
 modparam("rr", "enable_full_lr", 1)
 modparam("rr", "append_fromtag", 1)
 modparam("rr", "enable_double_rr", 1)
@@ -283,6 +289,40 @@ request_route {
             # Store the Contact header from 200 OK responses to INVITE
             $dlg_var(target_contact) = $ct;
             if ($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs - Stored Contact: $dlg_var(target_contact) \n");
+        }
+
+        # ------------------------------------------------------------------
+        # LOOPBACK DETECTION (ticket 430 step 3)
+        # ------------------------------------------------------------------
+        # Scenario "rivenditore di trunk": l'INVITE outbound caller-side
+        # esce verso il provider, il quale (stateless, vedendo la
+        # numerazione attestata sullo stesso egress) rilancia l'INVITE
+        # indietro verso lo stesso proxy. Ci ritroviamo cosi' due dialog
+        # locali (caller-side e callee-side) che condividono lo stesso
+        # From-tag (invariante end-to-end). Senza un legame esplicito tra
+        # di loro, BYE/in-dialog request da un lato non arrivano all'altro:
+        # il proxy le rimanda al provider statless che le ribalta in un
+        # loop e l'altro lato della chiamata resta appeso.
+        # Salvataggio per cross-dialog rewriting nel route[WITHINDLG]:
+        # - $ft come chiave invariante.
+        # - Per il primo INVITE iniziale visto (caller-side, direction=out
+        #   in REQUEST) salviamo CID e Contact del caller.
+        # - Per il secondo INVITE iniziale visto con lo stesso $ft (=
+        #   riflesso dal trunk, direction=in) salviamo CID e Contact del
+        #   callee, marchiamo entrambe le dialog come is_loopback=1.
+        if (is_method("INVITE") && !has_totag()) {
+            if ($dlg_var(direction) == "out" && $sht(loopback=>caller_ci_$ft) == $null) {
+                # primo INVITE iniziale caller-side
+                $sht(loopback=>caller_ci_$ft) = $ci;
+                $sht(loopback=>caller_ct_$ft) = $ct;
+                if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_ci=$ci caller_ct=$ct ft=$ft \n");
+            } else if ($dlg_var(direction) == "in" && $sht(loopback=>caller_ci_$ft) != $null) {
+                # secondo INVITE iniziale con stesso ft = riflesso dal trunk
+                $sht(loopback=>callee_ci_$ft) = $ci;
+                $sht(loopback=>callee_ct_$ft) = $ct;
+                $dlg_var(is_loopback) = "1";
+                xlog('L_WARN', "[FIX430-LB] loopback detected ft=$ft caller_ci=$sht(loopback=>caller_ci_$ft) callee_ci=$ci \n");
+            }
         }
     }
     # account only INVITEs
@@ -466,13 +506,71 @@ route[WITHINDLG] {
             record_route();
         }
 
-        # NOTA: stesso bug topos+mask_callid si manifesta anche su BYE/UPDATE/
-        # INFO/PRACK/MESSAGE/REFER in-dialog lato trunk-out (Kamailio issue
-        # #2905), ma per questo scenario "rivenditore Retelit" il fix richiede
-        # loopback detection: il BYE non deve essere instradato al provider
-        # (statless, lo rilancia indietro creando un loop e il caller non
-        # riceve mai il BYE) ma direttamente al peer interno della dialog
-        # opposta. Vedi step 3 del ticket 430.
+        # LOOPBACK CROSS-DIALOG REWRITE (ticket 430 step 3)
+        # In scenario "rivenditore stateless" il BYE/UPDATE/INFO da un lato
+        # della chiamata (caller o callee) non puo' transitare per il
+        # provider: lui lo rilancia statlessamente indietro e il messaggio
+        # rientra nel proxy come "in-dialog request" ricreando la stessa
+        # collisione che mask_callid risolveva all'INVITE iniziale.
+        # Soluzione: detection del loopback al setup (INVITE iniziale +
+        # riflesso con stesso From-tag) e cross-dialog rewrite della
+        # richiesta in-dialog: cambiamo Call-ID e To-tag alla dialog
+        # opposta cosi' topos sul rebuild outbound la indirizzi al peer
+        # interno corretto (caller<->callee) bypassando il provider.
+        #
+        # Chiave invariante: il From-tag che il caller ha assegnato all'
+        # INVITE iniziale (FT_inv). Nelle richieste in-dialog:
+        # - UAC su caller-side dialog (es. BYE caller->proxy): $ft = FT_inv
+        # - UAS su callee-side dialog (es. BYE callee->proxy): $tt = FT_inv
+        # Quindi tentiamo lookup htable prima su $ft, poi su $tt.
+        if (is_method("BYE|UPDATE|INFO|PRACK|MESSAGE|REFER") && has_totag()) {
+            $var(lb_key) = $null;
+            if ($sht(loopback=>caller_ci_$ft) != $null) {
+                $var(lb_key) = $ft;
+            } else if ($sht(loopback=>caller_ci_$tt) != $null) {
+                $var(lb_key) = $tt;
+            }
+            if ($var(lb_key) != $null) {
+                $var(lb_caller_ci) = $sht(loopback=>caller_ci_$var(lb_key));
+                $var(lb_callee_ci) = $sht(loopback=>callee_ci_$var(lb_key));
+                $var(lb_target_ci) = $null;
+                if ($ci == $var(lb_caller_ci)) {
+                    # da caller-side -> riscriviamo per dialog callee-side
+                    $var(lb_target_ci) = $var(lb_callee_ci);
+                    $var(lb_target_tt) = $sht(loopback=>callee_tt_$var(lb_key));
+                    $var(lb_target_ct) = $sht(loopback=>callee_ct_$var(lb_key));
+                    $var(lb_side) = "caller->callee";
+                } else if ($ci == $var(lb_callee_ci)) {
+                    # da callee-side -> riscriviamo per dialog caller-side
+                    $var(lb_target_ci) = $var(lb_caller_ci);
+                    $var(lb_target_tt) = $sht(loopback=>caller_tt_$var(lb_key));
+                    $var(lb_target_ct) = $sht(loopback=>caller_ct_$var(lb_key));
+                    $var(lb_side) = "callee->caller";
+                }
+                if ($var(lb_target_ci) != $null) {
+                    remove_hf("Call-ID");
+                    insert_hf("Call-ID: $var(lb_target_ci)\r\n", "Via");
+                    if ($var(lb_target_ct) != $null) {
+                        $var(lb_target_uri) = $(var(lb_target_ct){nameaddr.uri});
+                        if ($var(lb_target_uri) != $null) {
+                            $ru = $var(lb_target_uri);
+                            # forziamo next-hop fisico al Contact dell'altro
+                            # peer interno, cosi' forward() lo manda lui
+                            # direttamente bypassando topos+routing trunk
+                            $du = $var(lb_target_uri);
+                        }
+                    }
+                    if ($var(lb_target_tt) != $null) {
+                        uac_replace_to("", "$tu;tag=$var(lb_target_tt)");
+                    }
+                    remove_hf("Route");
+                    xlog('L_WARN', "[FIX430-LB] $rm cross-dialog rewrite $var(lb_side) key=$var(lb_key) old_ci=$ci -> new_ci=$var(lb_target_ci) new_tt=$var(lb_target_tt) ru=$ru du=$du \n");
+                    msg_apply_changes();
+                    forward();
+                    exit;
+                }
+            }
+        }
 
         # handling advanced NAT if this packet goes to private IP address and direction is OUT
         // if($ru{uri.host})
@@ -893,6 +991,31 @@ onreply_route[MANAGE_REPLY] {
                 $dlg_var(out_rr) = $hdr(Record-Route);
             }
             if ($shv(debug) == 1) xlog('L_WARN', "[FIX430] reply out 2xx: saved out_contact=$ct out_rr=$hdr(Record-Route) \n");
+        }
+
+        # LOOPBACK DETECTION step 3 (ticket 430): aggiorniamo i dati delle
+        # due dialog "caller-side" e "callee-side" dai 200 OK ricevuti.
+        # IMPORTANTE: il Call-ID che salviamo in REQINIT per il callee e'
+        # quello dell'INVITE inbound dal trunk; topos pero' rebuilda quel
+        # CID per la leg interna verso l'Asterisk callee, e quel CID
+        # rebuilded e' quello che il callee usera' nelle sue request
+        # in-dialog (incluso il BYE). Aggiorniamo qui callee_ci con il
+        # valore "lato Asterisk" leggendo il 200 OK in arrivo dal callee.
+        if ($rs =~ "2[0-9][0-9]" && is_method("INVITE") && $tt != $null) {
+            if ($sht(loopback=>caller_ci_$ft) != $null) {
+                # dialog loopback identificata
+                if ($avp(direction) == "in" && $ct != $null) {
+                    # 200 OK dal callee-side (reply da interno verso fuori)
+                    $sht(loopback=>callee_ci_$ft) = $ci;
+                    $sht(loopback=>callee_ct_$ft) = $ct;
+                    $sht(loopback=>callee_tt_$ft) = $tt;
+                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved callee_ci=$ci callee_ct=$ct callee_tt=$tt ft=$ft \n");
+                } else if ($avp(direction) == "out") {
+                    # 200 OK lato caller-side (reply dal trunk riflesso)
+                    $sht(loopback=>caller_tt_$ft) = $tt;
+                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_tt=$tt ft=$ft \n");
+                }
+            }
         }
 
         route(NATMANAGE);

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -524,13 +524,23 @@ route[WITHINDLG] {
         # - UAS su callee-side dialog (es. BYE callee->proxy): $tt = FT_inv
         # Quindi tentiamo lookup htable prima su $ft, poi su $tt.
         if (is_method("BYE|UPDATE|INFO|PRACK|MESSAGE|REFER") && has_totag()) {
-            $var(lb_key) = $null;
+            # reset esplicito: i $var sono per-process e mantengono lo
+            # state tra invocazioni della worker process; il ribaltamento
+            # stateless del BYE da parte del provider ri-entra in questo
+            # branch e senza reset si troverebbe valori stale di una
+            # chiamata precedente.
+            $var(lb_key) = "";
+            $var(lb_target_ci) = "";
+            $var(lb_target_tt) = "";
+            $var(lb_target_ct) = "";
+            $var(lb_target_uri) = "";
+            $var(lb_side) = "";
             if ($sht(loopback=>caller_ci_$ft) != $null) {
                 $var(lb_key) = $ft;
             } else if ($sht(loopback=>caller_ci_$tt) != $null) {
                 $var(lb_key) = $tt;
             }
-            if ($var(lb_key) != $null) {
+            if ($var(lb_key) != "") {
                 $var(lb_caller_ci) = $sht(loopback=>caller_ci_$var(lb_key));
                 $var(lb_callee_ci) = $sht(loopback=>callee_ci_$var(lb_key));
                 $var(lb_target_ci) = $null;
@@ -547,7 +557,7 @@ route[WITHINDLG] {
                     $var(lb_target_ct) = $sht(loopback=>caller_ct_$var(lb_key));
                     $var(lb_side) = "callee->caller";
                 }
-                if ($var(lb_target_ci) != $null) {
+                if ($var(lb_target_ci) != $null && $var(lb_target_ci) != "") {
                     remove_hf("Call-ID");
                     insert_hf("Call-ID: $var(lb_target_ci)\r\n", "Via");
                     if ($var(lb_target_ct) != $null) {
@@ -567,6 +577,49 @@ route[WITHINDLG] {
                     xlog('L_WARN', "[FIX430-LB] $rm cross-dialog rewrite $var(lb_side) key=$var(lb_key) old_ci=$ci -> new_ci=$var(lb_target_ci) new_tt=$var(lb_target_tt) ru=$ru du=$du \n");
                     msg_apply_changes();
                     forward();
+
+                    # STEP 4 (ticket 430): cleanup esplicito della leg
+                    # trunk-out verso il provider. Il cross-dialog rewrite
+                    # ha chiuso caller<->callee internamente, ma la leg
+                    # "proxy <-> provider" del dialog module e' rimasta
+                    # senza BYE: il provider la vedrebbe attiva fino al
+                    # session timer (tipicamente 30min) e topos/dialog
+                    # locale fino a dialog_expire (3.5h).
+                    # Il dialog module mantiene UNA sola dialog per la
+                    # chiamata loopback, con call-id = callee_ci
+                    # (mascherato sul trunk, demascherato dopo topos).
+                    # La caller-side di quella dialog ha route_set =
+                    # Record-Route del provider, quindi dlg_bye("caller")
+                    # emette un BYE outbound corretto verso il provider.
+                    if (is_method("BYE")) {
+                        # Cleanup esplicito della leg trunk-out del proxy
+                        # verso il provider. Le dialog del proxy hanno la
+                        # callee-side con route_set verso Retelit, quindi
+                        # dlg_bye("callee") emette un BYE outbound
+                        # corretto verso il provider.
+                        # Eseguito solo una volta, sulla dialog caller_ci
+                        # (che ha route_set Retelit settato sulla
+                        # callee-side dal MANAGE_REPLY 200 OK trunk-out).
+                        $var(lb_caller_ci) = $sht(loopback=>caller_ci_$var(lb_key));
+                        $var(lb_caller_tt) = $sht(loopback=>caller_tt_$var(lb_key));
+                        if ($var(lb_caller_ci) != $null && $var(lb_caller_tt) != $null) {
+                            if (dlg_get("$var(lb_caller_ci)", "$var(lb_key)", "$var(lb_caller_tt)")) {
+                                $var(lb_bye_rc) = dlg_bye("callee");
+                                xlog('L_WARN', "[FIX430-LB] cleanup trunk-out: dlg_bye('callee') rc=$var(lb_bye_rc) ci=$var(lb_caller_ci) \n");
+                            } else {
+                                xlog('L_WARN', "[FIX430-LB] cleanup trunk-out: dlg_get not found ci=$var(lb_caller_ci) \n");
+                            }
+                        }
+                        # Pulizia htable: il provider stateless ribalta il
+                        # BYE indietro e senza pulizia ri-entrerebbe in
+                        # cross-dialog rewrite generando un loop.
+                        $sht(loopback=>caller_ci_$var(lb_key)) = $null;
+                        $sht(loopback=>callee_ci_$var(lb_key)) = $null;
+                        $sht(loopback=>caller_ct_$var(lb_key)) = $null;
+                        $sht(loopback=>callee_ct_$var(lb_key)) = $null;
+                        $sht(loopback=>caller_tt_$var(lb_key)) = $null;
+                        $sht(loopback=>callee_tt_$var(lb_key)) = $null;
+                    }
                     exit;
                 }
             }
@@ -1001,6 +1054,10 @@ onreply_route[MANAGE_REPLY] {
         # rebuilded e' quello che il callee usera' nelle sue request
         # in-dialog (incluso il BYE). Aggiorniamo qui callee_ci con il
         # valore "lato Asterisk" leggendo il 200 OK in arrivo dal callee.
+        # Salviamo anche i dati della dialog trunk-out (200 OK direction=out)
+        # per poterla chiudere esplicitamente al BYE (step 4): senza
+        # questo cleanup la dialog "proxy <-> provider" resta appesa
+        # finche' dialog_expire (3.5h) o session timer del provider.
         if ($rs =~ "2[0-9][0-9]" && is_method("INVITE") && $tt != $null) {
             if ($sht(loopback=>caller_ci_$ft) != $null) {
                 # dialog loopback identificata
@@ -1013,7 +1070,13 @@ onreply_route[MANAGE_REPLY] {
                 } else if ($avp(direction) == "out") {
                     # 200 OK lato caller-side (reply dal trunk riflesso)
                     $sht(loopback=>caller_tt_$ft) = $tt;
-                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_tt=$tt ft=$ft \n");
+                    # i dati della dialog trunk-out (proxy <-> provider)
+                    # servono per chiuderla esplicitamente nel cross-dialog
+                    # rewrite (step 4): il CID che vediamo qui e' quello
+                    # mascherato verso il provider.
+                    $sht(loopback=>trunk_ci_$ft) = $ci;
+                    $sht(loopback=>trunk_tt_$ft) = $tt;
+                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_tt=$tt trunk_ci=$ci trunk_tt=$tt ft=$ft \n");
                 }
             }
         }

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -323,11 +323,18 @@ request_route {
                 $sht(loopback=>caller_ct_$ft) = $ct;
                 if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_ci=$ci caller_ct=$ct ft=$ft \n");
             } else if ($dlg_var(direction) == "in" && $sht(loopback=>caller_ci_$ft) != $null) {
-                # secondo INVITE iniziale con stesso ft = riflesso dal trunk
+                # secondo INVITE iniziale con stesso ft = riflesso dal trunk.
+                # Il CID che arriva qui ($ci) e' quello mascherato OUTBOUND
+                # del setup INVITE proxy->Retelit (Retelit, stateless,
+                # preserva il CID nel ribalto). Lo salviamo come
+                # trunk_out_masked_ci: ci servira' per emettere il BYE
+                # cleanup step 6 con il CID coerente al setup, in modo che
+                # sngrep raggruppi tutto sotto la stessa dialog.
                 $sht(loopback=>callee_ci_$ft) = $ci;
                 $sht(loopback=>callee_ct_$ft) = $ct;
+                $sht(loopback=>trunk_out_masked_ci_$ft) = $ci;
                 $dlg_var(is_loopback) = "1";
-                xlog('L_WARN', "[FIX430-LB] loopback detected ft=$ft caller_ci=$sht(loopback=>caller_ci_$ft) callee_ci=$ci \n");
+                xlog('L_WARN', "[FIX430-LB] loopback detected ft=$ft caller_ci=$sht(loopback=>caller_ci_$ft) callee_ci=$ci trunk_out_masked_ci=$ci \n");
             }
         }
     }
@@ -480,7 +487,18 @@ route[WITHINDLG] {
     # loopback_closed viene settato in cleanup branch (step 4)
     # contestualmente al dlg_bye.
     if (is_method("BYE") && $sht(loopback_closed=>$ci) != $null) {
-        xlog('L_WARN', "[FIX430-LB] absorb provider BYE bounce ci=$ci - reply 200 OK and drop\n");
+        # Il valore in htable e' il Call-ID mascherato outbound: lo
+        # riscriviamo nel messaggio prima della response 200 OK in modo
+        # che la response esca con il CID coerente al setup INVITE, e
+        # sngrep raggruppi setup + BYE + 200 OK assorbito sotto la stessa
+        # dialog (no piu' "IN CALL" fantasma per la dialog mascherata).
+        $var(absorb_masked_ci) = $sht(loopback_closed=>$ci);
+        if ($var(absorb_masked_ci) != $null && $var(absorb_masked_ci) != "1") {
+            remove_hf("Call-ID");
+            insert_hf("Call-ID: $var(absorb_masked_ci)\r\n", "Via");
+            msg_apply_changes();
+        }
+        xlog('L_WARN', "[FIX430-LB] absorb provider BYE bounce ci=$ci masked=$var(absorb_masked_ci) - reply 200 OK and drop\n");
         sl_send_reply("200", "OK");
         exit;
     }
@@ -614,34 +632,70 @@ route[WITHINDLG] {
                     # emette un BYE outbound corretto verso il provider.
                     if (is_method("BYE")) {
                         # Cleanup esplicito della leg trunk-out del proxy
-                        # verso il provider. Le dialog del proxy hanno la
-                        # callee-side con route_set verso Retelit, quindi
-                        # dlg_bye("callee") emette un BYE outbound
-                        # corretto verso il provider.
-                        # Eseguito solo una volta, sulla dialog caller_ci
-                        # (che ha route_set Retelit settato sulla
-                        # callee-side dal MANAGE_REPLY 200 OK trunk-out).
-                        $var(lb_caller_ci) = $sht(loopback=>caller_ci_$var(lb_key));
-                        $var(lb_caller_tt) = $sht(loopback=>caller_tt_$var(lb_key));
-                        if ($var(lb_caller_ci) != $null && $var(lb_caller_tt) != $null) {
-                            if (dlg_get("$var(lb_caller_ci)", "$var(lb_key)", "$var(lb_caller_tt)")) {
-                                $var(lb_bye_rc) = dlg_bye("callee");
-                                xlog('L_WARN', "[FIX430-LB] cleanup trunk-out: dlg_bye('callee') rc=$var(lb_bye_rc) ci=$var(lb_caller_ci) \n");
-                            } else {
-                                xlog('L_WARN', "[FIX430-LB] cleanup trunk-out: dlg_get not found ci=$var(lb_caller_ci) \n");
+                        # verso il provider, emettendo un secondo forward
+                        # con i parametri della dialog trunk-out.
+                        # Storia: il primo tentativo usava dlg_get +
+                        # dlg_bye("callee"), ma dlg_bye di Kamailio bypassa
+                        # il rebuild di topos -> il BYE arrivava a Retelit
+                        # con il CID interno non mascherato, diverso dal
+                        # CID del setup INVITE (mascherato), causando una
+                        # dialog "fantasma" in sngrep (vista IN CALL senza
+                        # BYE per il CID mascherato). Soluzione: forward()
+                        # stateless con i campi della dialog trunk-out
+                        # (Contact UAS, Record-Route, next-hop fisico).
+                        # Topos sull'outbound mascherera' il CID basandosi
+                        # sullo stato Redis della dialog caller_ci, in
+                        # modo coerente col setup INVITE.
+                        # Step 4 (forward BYE outbound verso il provider) con
+                        # CID mascherato coerente al setup INVITE (catturato
+                        # in REQINIT all'INVITE riflesso). Cosi' sngrep,
+                        # che raggruppa per Call-ID, vede sulla dialog
+                        # mascherata trunk-out: INVITE -> 200 OK -> ACK ->
+                        # BYE -> BYE ribalto -> 200 OK assorbito (step 5).
+                        # Il provider stateless non rispondera' al nostro
+                        # BYE ma ribaltera' indietro (gestito da step 5).
+                        $var(out_ct) = $sht(loopback=>trunk_out_contact_$var(lb_key));
+                        $var(out_rr) = $sht(loopback=>trunk_out_rr_$var(lb_key));
+                        $var(out_masked_ci) = $sht(loopback=>trunk_out_masked_ci_$var(lb_key));
+                        if ($var(out_ct) != $null && $var(out_rr) != $null && $var(out_masked_ci) != $null) {
+                            $var(out_ct_uri) = $(var(out_ct){nameaddr.uri});
+                            $var(out_rr_uri) = $(var(out_rr){nameaddr.uri});
+                            if ($var(out_ct_uri) != $null && $var(out_rr_uri) != $null) {
+                                $ru = $var(out_ct_uri);
+                                remove_hf("Route");
+                                append_hf("Route: <$var(out_rr_uri)>\r\n");
+                                $du = "sip:" + $(var(out_rr_uri){uri.host}) + ":" + $(var(out_rr_uri){uri.port});
+                                if ($(var(out_rr_uri){uri.port}) == "") {
+                                    $du = "sip:" + $(var(out_rr_uri){uri.host}) + ":5060";
+                                }
+                                # CID mascherato = coerente al setup INVITE
+                                remove_hf("Call-ID");
+                                insert_hf("Call-ID: $var(out_masked_ci)\r\n", "Via");
+                                # Force socket esterno
+                                $fs = "udp:" + $env(PUBLIC_IP) + ":5060";
+                                xlog('L_WARN', "[FIX430-LB] step4 forward BYE trunk-out: ci=$var(out_masked_ci) ru=$ru du=$du fs=$fs \n");
+                                msg_apply_changes();
+                                forward();
                             }
                         }
-                        # Memorizziamo CID e ft delle dialog appena chiuse:
-                        # il provider stateless ribalta il BYE che abbiamo
-                        # appena emesso (dlg_bye) e senza questo marker il
-                        # proxy lo propagherebbe al callee asterisk che
-                        # risponderebbe 481 (transazione non riconosciuta).
-                        # Vedi check in cima al WITHINDLG.
+                        # Memorizziamo CID delle dialog appena chiuse (per
+                        # assorbire il ribalto del provider stateless):
+                        # il provider rilancia il BYE che abbiamo appena
+                        # emesso, e senza questo marker il proxy lo
+                        # propagherebbe al callee asterisk -> 481.
+                        # Salviamo come VALORE del marker il CID mascherato
+                        # outbound: cosi' nello step 5 absorb possiamo
+                        # riscrivere il Call-ID della response 200 OK al
+                        # mascherato, in modo che sngrep raggruppi tutto
+                        # sotto la stessa dialog del setup INVITE.
                         if ($var(lb_caller_ci) != $null) {
-                            $sht(loopback_closed=>$var(lb_caller_ci)) = "1";
+                            $sht(loopback_closed=>$var(lb_caller_ci)) = $var(out_masked_ci);
                         }
                         if ($var(lb_callee_ci) != $null) {
-                            $sht(loopback_closed=>$var(lb_callee_ci)) = "1";
+                            $sht(loopback_closed=>$var(lb_callee_ci)) = $var(out_masked_ci);
+                        }
+                        if ($var(out_masked_ci) != $null) {
+                            $sht(loopback_closed=>$var(out_masked_ci)) = $var(out_masked_ci);
                         }
                         # Pulizia htable principale: il provider stateless ribalta il
                         # BYE indietro e senza pulizia ri-entrerebbe in
@@ -652,6 +706,9 @@ route[WITHINDLG] {
                         $sht(loopback=>callee_ct_$var(lb_key)) = $null;
                         $sht(loopback=>caller_tt_$var(lb_key)) = $null;
                         $sht(loopback=>callee_tt_$var(lb_key)) = $null;
+                        $sht(loopback=>trunk_out_contact_$var(lb_key)) = $null;
+                        $sht(loopback=>trunk_out_rr_$var(lb_key)) = $null;
+                        $sht(loopback=>trunk_out_masked_ci_$var(lb_key)) = $null;
                     }
                     exit;
                 }
@@ -1109,7 +1166,13 @@ onreply_route[MANAGE_REPLY] {
                     # mascherato verso il provider.
                     $sht(loopback=>trunk_ci_$ft) = $ci;
                     $sht(loopback=>trunk_tt_$ft) = $tt;
-                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_tt=$tt trunk_ci=$ci trunk_tt=$tt ft=$ft \n");
+                    if ($ct != $null) {
+                        $sht(loopback=>trunk_out_contact_$ft) = $ct;
+                    }
+                    if ($hdr(Record-Route) != $null) {
+                        $sht(loopback=>trunk_out_rr_$ft) = $hdr(Record-Route);
+                    }
+                    if ($shv(debug) == 1) xlog('L_WARN', "[FIX430-LB] saved caller_tt=$tt trunk_ci=$ci trunk_tt=$tt trunk_out_ct=$ct trunk_out_rr=$hdr(Record-Route) ft=$ft \n");
                 }
             }
         }

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -129,6 +129,12 @@ modparam("htable", "htable", "apibanctl=>size=1;initval=0;")
 # callee-side), per cross-dialog rewriting di BYE/in-dialog in WITHINDLG.
 # autoexpire 3600s = TTL ragionevole per dialog non chiuse correttamente.
 modparam("htable", "htable", "loopback=>size=10;autoexpire=3600;")
+# loopback_closed: marker per BYE appena emessi verso il provider via
+# dlg_bye. Permette di assorbire il ribaltamento stateless dello stesso
+# BYE che il provider ci rimanda, evitando di propagarlo al peer
+# interno (che genererebbe 481). TTL breve perche' il ribalto avviene
+# nei primi secondi dopo l'emissione.
+modparam("htable", "htable", "loopback_closed=>size=10;autoexpire=60;")
 modparam("rr", "enable_full_lr", 1)
 modparam("rr", "append_fromtag", 1)
 modparam("rr", "enable_double_rr", 1)
@@ -464,6 +470,21 @@ route[WITHINDLG] {
     }
     if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - in WITHINDLG route \n");
 
+    # STEP 5 (ticket 430): assorbi il ribaltamento stateless del BYE
+    # dal provider. Dopo che lo step 4 ha emesso un BYE outbound via
+    # dlg_bye("callee"), il provider statless ce lo rimanda indietro
+    # (= comportamento di loose-routing su Route header che lo punta a
+    # se stesso). Senza intercettarlo qui, il proxy lo propagherebbe
+    # al callee asterisk che risponderebbe 481 ("Transaction Does Not
+    # Exist") perche' la sua dialog ha gia' altro CID. Il marker
+    # loopback_closed viene settato in cleanup branch (step 4)
+    # contestualmente al dlg_bye.
+    if (is_method("BYE") && $sht(loopback_closed=>$ci) != $null) {
+        xlog('L_WARN', "[FIX430-LB] absorb provider BYE bounce ci=$ci - reply 200 OK and drop\n");
+        sl_send_reply("200", "OK");
+        exit;
+    }
+
     if (loose_route()) {
         if ($shv(debug) == 1 ) xlog('L_WARN', "[DEV] - $ci $rm-$cs - loose_route is OK, doing DLGURI \n");
         route(DLGURI);
@@ -610,7 +631,19 @@ route[WITHINDLG] {
                                 xlog('L_WARN', "[FIX430-LB] cleanup trunk-out: dlg_get not found ci=$var(lb_caller_ci) \n");
                             }
                         }
-                        # Pulizia htable: il provider stateless ribalta il
+                        # Memorizziamo CID e ft delle dialog appena chiuse:
+                        # il provider stateless ribalta il BYE che abbiamo
+                        # appena emesso (dlg_bye) e senza questo marker il
+                        # proxy lo propagherebbe al callee asterisk che
+                        # risponderebbe 481 (transazione non riconosciuta).
+                        # Vedi check in cima al WITHINDLG.
+                        if ($var(lb_caller_ci) != $null) {
+                            $sht(loopback_closed=>$var(lb_caller_ci)) = "1";
+                        }
+                        if ($var(lb_callee_ci) != $null) {
+                            $sht(loopback_closed=>$var(lb_callee_ci)) = "1";
+                        }
+                        # Pulizia htable principale: il provider stateless ribalta il
                         # BYE indietro e senza pulizia ri-entrerebbe in
                         # cross-dialog rewrite generando un loop.
                         $sht(loopback=>caller_ci_$var(lb_key)) = $null;

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -457,6 +457,7 @@ route[WITHINDLG] {
                     }
                 }
                 if ($shv(debug) == 1) xlog('L_WARN', "[FIX430] ACK trunk-out forced ru=$ru rr=$dlg_var(out_rr) - stateless forward \n");
+                msg_apply_changes();
                 forward();
                 exit;
             }
@@ -464,6 +465,15 @@ route[WITHINDLG] {
             # Add Record-Route for in-dialog NOTIFY as per RFC 6665.
             record_route();
         }
+
+        # NOTA: stesso bug topos+mask_callid si manifesta anche su BYE/UPDATE/
+        # INFO/PRACK/MESSAGE/REFER in-dialog lato trunk-out (Kamailio issue
+        # #2905), ma per questo scenario "rivenditore Retelit" il fix richiede
+        # loopback detection: il BYE non deve essere instradato al provider
+        # (statless, lo rilancia indietro creando un loop e il caller non
+        # riceve mai il BYE) ma direttamente al peer interno della dialog
+        # opposta. Vedi step 3 del ticket 430.
+
         # handling advanced NAT if this packet goes to private IP address and direction is OUT
         // if($ru{uri.host})
         # Handle BYE with stored Contact when loose_route fails

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -597,6 +597,15 @@ route[WITHINDLG] {
                     $var(lb_side) = "callee->caller";
                 }
                 if ($var(lb_target_ci) != $null && $var(lb_target_ci) != "") {
+                    # Per i BYE: risposta locale 200 OK al peer che ha
+                    # emesso il BYE, sulla SUA dialog (= CID del messaggio
+                    # entrante prima del rewrite). Senza questo, il peer
+                    # vede il BYE forwardato senza ricevere il 200 OK e
+                    # sngrep mostrerebbe la dialog del peer in "CALL
+                    # SETUP" (manca 200 OK BYE).
+                    if (is_method("BYE")) {
+                        sl_send_reply("200", "OK");
+                    }
                     remove_hf("Call-ID");
                     insert_hf("Call-ID: $var(lb_target_ci)\r\n", "Via");
                     if ($var(lb_target_ct) != $null) {

--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -86,6 +86,7 @@ loadmodule "http_client.so"
 loadmodule "jansson.so"
 loadmodule "rtimer.so"
 loadmodule "ndb_redis.so"
+loadmodule "topoh.so"
 loadmodule "topos.so"
 loadmodule "topos_redis.so"
 loadmodule "sqlops.so"
@@ -146,8 +147,19 @@ modparam("pike", "reqs_density_per_unit", 50)
 # Keeping an IP in memory results in faster reaching of blocked state -- see the notes about the limits of getting to state 'blocked'.
 modparam("pike", "remove_latency", 4)
 modparam("ndb_redis", "server", NDB_REDIS_SERVER)
+# topoh caricato come libreria: topos mask_callid usa la sua API (bind_topoh)
+# per codificare il Call-ID. mask_key e' la chiave dell'algoritmo di encoding.
+modparam("topoh", "mask_key", "nethvoiceProxyT0p0sM4sk")
 modparam("topos", "storage", "redis")
 modparam("topos", "dialog_expire", 12600)
+# mask_callid: il Call-ID verso l'esterno viene codificato/mascherato.
+# Necessario per lo scenario "rivenditore trunk" (ticket 430): quando il
+# provider (es. Kamailio Retelit stateless) riflette l'INVITE verso lo stesso
+# proxy preservando Call-ID/From-tag, senza mascheramento il leg riflesso
+# collide con il dialog/sessione rtpengine del leg di andata (stesso Call-ID).
+# Con mask_callid il rientro porta un Call-ID diverso da quello interno e il
+# proxy lo tratta come dialogo nuovo verso l'altra istanza NethVoice.
+modparam("topos", "mask_callid", 1)
 modparam("topos_redis", "serverid", "srv1")
 #!ifdef WITH_RTPENGINE
 modparam("rtpengine", "db_url", DBURL)


### PR DESCRIPTION
## What this changes

This PR fixes the trunk-to-trunk flow between two NethVoice instances on the same node when both are registered on the same Retelit Kamailio proxy.

The call path is now working end to end: setup, audio, ACK, teardown from both sides, and final dialog cleanup.

## Why

The issue came from using `topos` plus `mask_callid` as if they were a B2BUA, even though they only provide topology hiding and do not own dialog state.

This caused Call-ID collisions, ACK problems, cross-dialog BYE behavior, and incomplete-looking masked dialogs in sngrep.

## Details

Main changes:

- Call-ID masking toward the provider to avoid dialog collisions.
- Correct 2xx ACK reconstruction in `route[WITHINDLG]`.
- Loopback handling for in-dialog requests by rewriting Call-ID, To-tag, and R-URI toward the opposite internal peer.
- `loopback_closed` handling to absorb the provider’s reflected BYE and reply locally with `200 OK`.
- Custom local image setup so the fix survives container recreation.

## Testing

| Aspect | Result |
|--|--|
| INVITE setup reflected without collision | OK |
| Bidirectional audio | OK |
| End-to-end ACK formatting | OK |
| BYE propagation from callee | OK |
| BYE propagation from caller | OK |
| Asterisk channels at end of call | 0 / 0 |
| Residual Kamailio dialogs | 0 |

## Notes

There is still a cosmetic limitation in sngrep: one masked dialog may appear incomplete because `topos` does not reapply masking consistently for some proxy-generated responses or requests.

This is a structural limitation of `topos`, so it cannot be fixed locally without changing the architecture or patching upstream.
