### PR TITLE
fix: disable rtpengine kernel forwarding and guard SDP NAT check

### DIFF
--- a/modules/kamailio/config/kamailio.cfg
+++ b/modules/kamailio/config/kamailio.cfg
@@ -699,13 +699,11 @@ route[NATMANAGE] {
         route(SET_SOCKET);
         # Adding loog protection and ICE removing
         $var(rtpengine_conf) = "" + $var(rtpengine_conf) + " ICE=remove";
-        if (nat_uac_test("8")) {
-            if (has_body("application/sdp")) {
+        if (has_body("application/sdp")) {
+            if (nat_uac_test("8")) {
                 if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs ($rs) - calling rtpengine_manage: replace-origin replace-session-connection $var(rtpengine_conf) \n");
                 rtpengine_manage("replace-origin replace-session-connection $var(rtpengine_conf)");
-            }
-        } else {
-            if (has_body("application/sdp")) {
+            } else {
                 if($shv(debug) == 1) xlog('L_WARN', "[DEV] - $ci $rm-$cs ($rs) - trust-address replace-origin replace-session-connection symmetric-codecs codec-transcode-all $var(rtpengine_conf) \n");
                 rtpengine_manage("trust-address replace-origin replace-session-connection symmetric-codecs codec-transcode-all $var(rtpengine_conf)");
             }

--- a/modules/rtpengine/files/rtpengine.conf.template
+++ b/modules/rtpengine/files/rtpengine.conf.template
@@ -1,5 +1,5 @@
 [rtpengine]
-table = 0
+table = -1
 
 ${INTERFACE_SECTION}
 listen-ng = 127.0.0.1:19999


### PR DESCRIPTION
Two fixes to suppress noisy and misleading log output in the proxy container:

- **rtpengine**: Set `table = -1` in the generated configuration to disable
  kernel forwarding. This prevents repeated warnings when the optional kernel
  module is not loaded in the container environment.

- **kamailio**: Reorder the SDP/NAT check in `route[NATMANAGE]` so that
  `has_body("application/sdp")` is evaluated before `nat_uac_test("8")`.
  This avoids parser errors logged for SIP messages that do not carry an SDP
  body, while keeping malformed SDP visible for troubleshooting.

## Related issue

None

## How to test

1. Deploy the module and make a call.
2. Check rtpengine logs — no kernel-forwarding warnings should appear.
3. Send SIP messages without an SDP body (e.g., OPTIONS, REGISTER) through
   Kamailio and confirm no SDP parser errors are logged.
4. Verify that calls with SDP still work correctly (NAT traversal, codec
   transcoding).

## Dependencies

None